### PR TITLE
修改连接 OpenGauss 数据库时，定时会话清理任务报错的问题

### DIFF
--- a/backend/studio-manager-service/src/main/java/com/openjiuwen/studio/agent/manager/repository/SessionRepository.java
+++ b/backend/studio-manager-service/src/main/java/com/openjiuwen/studio/agent/manager/repository/SessionRepository.java
@@ -32,7 +32,7 @@ public interface SessionRepository extends JpaRepository<Session, Long> {
     int expireSessions(@Param("currentTime") LocalDateTime currentTime);
 
     @Modifying
-    @Query("DELETE FROM Session WHERE loginTime < :retentionTime")
+    @Query(value = "DELETE FROM t_sessions WHERE login_time < :retentionTime", nativeQuery = true)
     int deleteOldSessions(@Param("retentionTime") LocalDateTime retentionTime);
 
 }


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

**What type of PR is this?**
/kind bug

**Self-checklist**:
+ - [x] **设计**：方案为单行 SQL 注解修复，已与 Maintainer 沟通确认
+ - [x] **测试**：已在 Gauss 环境验证修复前后行为，日志确认 SQL 正确下发与执行
+ - [x] **验证**：详见下方验证结果
+ - [x] **接口**：不涉及对外接口变更
+ - [x] **文档**：不涉及文档修改

---

## 改动总结

### 问题现象

定时任务 `SessionCleanupConfig.cleanupExpiredSessions()` 执行失败，openGauss 数据库报语法错误：
ERROR: syntax error at or near "s1_0" Position: 24
SQL: delete from t_sessions s1_0 where s1_0.login_time<?


### 根因分析

`SessionRepository.deleteOldSessions()` 使用 JPQL 定义 DELETE 语句：

```java
@Query("DELETE FROM Session WHERE loginTime < :retentionTime")
int deleteOldSessions(@Param("retentionTime") LocalDateTime retentionTime);
```

Hibernate 6.6.8 将 JPQL 翻译为 SQL 时，**强制为表生成别名 `s1_0`**，生成 SQL：

```sql
delete from t_sessions s1_0 where s1_0.login_time<?
```

而 openGauss（PostgreSQL 系）的 `DELETE` 语法**不支持表别名**（与 MySQL/MariaDB 不同），导致语法错误。

UPDATE 语句虽然也带别名 `s1_0`，但 openGauss 的 UPDATE 语法允许表别名，故未报错。

### 修复方案

改用原生 SQL（`nativeQuery = true`），绕过 Hibernate 的自动别名生成机制：

```java
// 修改前
@Query("DELETE FROM Session WHERE loginTime < :retentionTime")

// 修改后
@Query(value = "DELETE FROM t_sessions WHERE login_time < :retentionTime", nativeQuery = true)
```

### 兼容性

`DELETE FROM t_sessions WHERE login_time < ?` 是 ANSI SQL 标准语法，兼容主流数据库：
- ✅ openGauss / PostgreSQL
- ✅ MySQL / MariaDB
- ✅ Oracle / SQL Server / DB2 / H2

### 改动范围

仅 1 个文件 1 行代码：
- `backend/studio-manager-service/src/main/java/com/openjiuwen/studio/agent/manager/repository/SessionRepository.java`

---

## 验证结果

![d26ba3f09fe69d0619d5556c5385c3b3.png](https://raw.gitcode.com/user-images/assets/8766979/87422720-7325-44f1-9ea5-014ec62e188b/d26ba3f09fe69d0619d5556c5385c3b3.png 'd26ba3f09fe69d0619d5556c5385c3b3.png')