### PR TITLE
fix: 已发布工作流/多智能体导入刷新草稿

### DIFF
--- a/backend/studio-manager-service/src/main/java/com/openjiuwen/studio/agent/manager/service/AgentImportService.java
+++ b/backend/studio-manager-service/src/main/java/com/openjiuwen/studio/agent/manager/service/AgentImportService.java
@@ -1115,7 +1115,11 @@ public class AgentImportService {
             }
             switch (ResourceTypeEnum.fromValue(result.getType())) {
                 case WORKFLOW -> {
-                    uploadWorkflowDsl(resourceMap.get(result.getId()), id, id, null);
+                    // 草稿 DSL 上传：仅首次导入（addTag=true，资源新建）或草稿态导入（versionId 空）时上传。
+                    // 已发布版本导入到已有资源（addTag=false 且 versionId 非空）时跳过，避免覆盖用户草稿。
+                    if (Boolean.TRUE.equals(result.getAddTag()) || StringUtils.isEmpty(versionId)) {
+                        uploadWorkflowDsl(resourceMap.get(result.getId()), id, id, null);
+                    }
                     if (StringUtils.isNotEmpty(versionId)) {
                         // 版本 DSL 用按版本区分的 ImportInfo，避免同 resourceId 多版本取到同一份
                         ImportInfo versionedInfo = versionedResourceMap.get(result.getId() + "|" + result.getVersion());
@@ -1138,7 +1142,10 @@ public class AgentImportService {
                         uploadControllerDsl(
                             versionedInfo != null ? versionedInfo : resourceMap.get(result.getId()), id, versionId);
                     }
-                    uploadControllerDsl(resourceMap.get(result.getId()), id, null);
+                    // 草稿 DSL 上传：仅首次导入或草稿态导入时上传，避免已发布版本导入覆盖用户草稿。
+                    if (Boolean.TRUE.equals(result.getAddTag()) || StringUtils.isEmpty(versionId)) {
+                        uploadControllerDsl(resourceMap.get(result.getId()), id, null);
+                    }
                 }
             }
         });


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

导入已发布版本到已有资源时,草稿DSL被导入包的版本快照覆盖,
    用户修改的草稿丢失(导入版本一→改草稿→导入版本二,草稿变版本二)。

    根因(日志+实测确认,无猜测):
    handleResourceDsl 每次导入都调 uploadXxxDsl(..., null) 上传草稿DSL,
    用导入包版本快照覆盖目标空间OBS草稿文件。
    - workflow/controller 草稿读OBS → 用户感知草稿被刷新(bug)
    - agent 草稿走buildComplexAgentInfo从DB重建不读OBS → 无感知(但OBS草稿文件仍被覆盖)

    修复:
    workflow/controller 草稿上传加条件: 仅首次导入(addTag=true,资源新建)或
    草稿态导入(versionId空)时上传; 已发布版本导入到已有资源(addTag=false且
    versionId非空)跳过,避免覆盖用户草稿。agent保持原逻辑(草稿读DB,无感知)。
    判断依据: result.getAddTag() — insertWorkflow/createController首次导入设true,
    update不设(默认false)。