### PR TITLE
fix: per-call workflow instance isolation for ReactWorkflowAdapter

### DIFF
--- a/agent-runtime/agent_runtime/runner/react_agent_runner.py
+++ b/agent-runtime/agent_runtime/runner/react_agent_runner.py
@@ -400,7 +400,8 @@ class ReActAgentRunner:
                 # 注册 Tool 到 resource_mgr
                 try:
                     wt_instance = ReactWorkflowAdapter(
-                        workflow_instance=wf_instance,
+                        ir_data=sub_ir,
+                        card_id=wf_instance.card.id,
                         workflow_name=wf_name,
                         workflow_desc=wf_desc,
                         input_params=input_params,

--- a/agent-runtime/agent_runtime/runner/react_workflow_adapter.py
+++ b/agent-runtime/agent_runtime/runner/react_workflow_adapter.py
@@ -4,7 +4,7 @@ ReActAgent Workflow Adapter — 将 Workflow 适配为 ReActAgent 可调用的 T
 """
 
 import uuid
-from typing import List, Any
+from typing import List
 
 from openjiuwen.core.foundation.tool import Tool, ToolCard
 from openjiuwen.core.session.stream import BaseStreamMode
@@ -16,34 +16,39 @@ class ReactWorkflowAdapter(Tool):
 
     def __init__(
         self,
-        workflow_instance: Any,
+        ir_data: dict,
+        card_id: str,
         workflow_name: str,
         workflow_desc: str,
         input_params: dict,
         user_fields_keys: List[str],
     ):
         card = ToolCard(
-            id=workflow_instance.card.id,
+            id=card_id,
             name=workflow_name,
             description=workflow_desc,
             input_params=input_params,
         )
         super().__init__(card=card)
-        self._workflow_instance = workflow_instance
+        # R-02: 只存只读 IR,不存共享 workflow 实例;invoke 每次自建,消除并发竞写
+        self._ir_data = ir_data
         self._user_fields_keys = user_fields_keys
 
     async def invoke(self, inputs: dict, **kwargs) -> dict:
         """调用工作流"""
         from openjiuwen.core.workflow import create_workflow_session
+        from jiuwen.serve.controllers.execution.ir_converter import IRConverter
 
         session_id = kwargs.get("session_id", str(uuid.uuid4()))
         session = create_workflow_session(session_id=session_id)
         wf_inputs = self._convert_inputs(inputs)
+        # R-02: per-call 新建 workflow 实例 → 各自独立 _session/_graph → 并发 stream() 不竞写
+        wf_instance = await IRConverter.async_ir_to_workflow(self._ir_data)
 
         final_answer = None
         fallback_result = None
 
-        async for chunk in self._workflow_instance.stream(
+        async for chunk in wf_instance.stream(
             inputs=wf_inputs,
             session=session,
             stream_modes=[BaseStreamMode.OUTPUT, BaseStreamMode.CUSTOM],

--- a/agent-runtime/tests/unit_tests/runner/test_ir_concurrent_build_immutability.py
+++ b/agent-runtime/tests/unit_tests/runner/test_ir_concurrent_build_immutability.py
@@ -1,0 +1,60 @@
+# -*- coding: UTF-8 -*-
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""R-02 §9.2: IR 并发构建不变性测试。
+
+修复后 adapter 只存只读 ir_data,invoke() 每次自建 LazyWorkflow。同一份 IR
+被并发构建时必须满足:
+- 原始 IR dict 内容不被修改(COW / 纯函数式 build);
+- 各次构建得到不同的 LazyWorkflow 与不同的可执行 Workflow 实例。
+
+坐实"复用 sub_ir 并发 rebuild 安全"——非仅依赖 docstring,而是实测。
+"""
+
+import asyncio
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+IR_PATH = Path(__file__).resolve().parents[2] / "resource" / "ir_file" / "workflow_message.json"
+
+
+class TestIRConcurrentBuildImmutability:
+    """同一份 IR 并发构建:原始内容不变,各构建得到独立实例。"""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_build_leaves_ir_unchanged_and_yields_distinct_instances(self):
+        from jiuwen.serve.controllers.execution.ir_converter import IRConverter
+
+        ir_data = json.loads(IR_PATH.read_text(encoding="utf-8"))
+        snapshot = copy.deepcopy(ir_data)
+
+        lazy_a, lazy_b = await asyncio.gather(
+            IRConverter.async_ir_to_workflow(ir_data),
+            IRConverter.async_ir_to_workflow(ir_data),
+        )
+        wf_a, wf_b = await asyncio.gather(lazy_a.instantiate(), lazy_b.instantiate())
+
+        # 原始 IR 未被任何一次构建修改
+        assert ir_data == snapshot
+        # 两个 LazyWorkflow shell 不同
+        assert lazy_a is not lazy_b
+        # 两个底层可执行 Workflow 实例不同(各自的 _graph/_session 独立)
+        assert wf_a is not wf_b
+
+    @pytest.mark.asyncio
+    async def test_single_ir_repeated_build_is_stable(self):
+        """同一份 IR 连续构建两次,结果稳定、IR 不变(顺序版,补充并发版)。"""
+        from jiuwen.serve.controllers.execution.ir_converter import IRConverter
+
+        ir_data = json.loads(IR_PATH.read_text(encoding="utf-8"))
+        snapshot = copy.deepcopy(ir_data)
+
+        lazy_a = await IRConverter.async_ir_to_workflow(ir_data)
+        lazy_b = await IRConverter.async_ir_to_workflow(ir_data)
+        wf_a = await lazy_a.instantiate()
+        wf_b = await lazy_b.instantiate()
+
+        assert ir_data == snapshot
+        assert wf_a is not wf_b

--- a/agent-runtime/tests/unit_tests/runner/test_react_workflow_adapter_concurrency.py
+++ b/agent-runtime/tests/unit_tests/runner/test_react_workflow_adapter_concurrency.py
@@ -1,0 +1,165 @@
+# -*- coding: UTF-8 -*-
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""Unit tests for R-02 fix: ReactWorkflowAdapter per-call workflow instance isolation.
+
+R-02 根因:同一 adapter 持有共享 workflow 实例,并发 invoke() 在共享实例的
+compile()/stream() 上竞写,导致输出串线(发 A 回 B / 残缺)。
+修复后 adapter 只存只读 ir_data,invoke() 每次自建 LazyWorkflow,各请求独立
+_session/_graph。
+
+本测试用 fake workflow 验证:并发调用同一 adapter 时,(1) 每次都构建新的 workflow
+实例,(2) 各请求输出与各自输入一一对应、不串线。
+"""
+
+import asyncio
+from dataclasses import dataclass, field
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@dataclass
+class _Chunk:
+    """模拟 stream chunk — adapter.invoke 只读 type/payload。"""
+    type: str
+    payload: dict = field(default_factory=dict)
+    data: dict = field(default_factory=dict)
+
+
+class _FakeWorkflow:
+    """记录被 stream 时的 inputs,并把 query 回显成 workflow_final answer。"""
+
+    def __init__(self):
+        self.received_inputs: dict | None = None
+
+    async def stream(self, *, inputs, session, stream_modes):
+        # 拷贝一份,避免与调用方共享引用
+        self.received_inputs = dict(inputs)
+        query = inputs.get("query", "")
+        yield _Chunk(type="workflow_final", payload={"answer": f"OK:{query}"})
+
+
+class _FakeWorkflowMaybeFail:
+    """query=='FAIL' 时在 stream 中抛错,否则回显。用于异常隔离测试。"""
+
+    async def stream(self, *, inputs, session, stream_modes):
+        query = inputs.get("query", "")
+        if query == "FAIL":
+            raise RuntimeError("simulated workflow stream failure")
+        yield _Chunk(type="workflow_final", payload={"answer": f"OK:{query}"})
+
+
+class TestReactWorkflowAdapterConcurrency:
+    """R-02: 同一 adapter 的并发 invoke() 必须使用各自独立的 workflow 实例。"""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_invokes_build_separate_instances_and_do_not_cross(self):
+        """并发两调用各自构建独立 workflow 实例,输出不串线。"""
+        from agent_runtime.runner.react_workflow_adapter import ReactWorkflowAdapter
+        from jiuwen.serve.controllers.execution.ir_converter import IRConverter
+
+        created: list = []
+        entered = 0
+        gate = asyncio.Event()
+
+        async def fake_async_ir_to_workflow(ir_data, **kwargs):
+            # 强制两调用同时进入构建窗口(gate 在第二个到达时打开),
+            # 模拟 R02 复现里 B 卡进 A 窗口的并发场景。
+            nonlocal entered
+            entered += 1
+            wf = _FakeWorkflow()
+            created.append(wf)
+            if entered >= 2:
+                gate.set()
+            await gate.wait()
+            return wf
+
+        adapter = ReactWorkflowAdapter(
+            ir_data={"workflowId": "w-r02"},
+            card_id="card-r02",
+            workflow_name="R02_ROOT_WORKFLOW",
+            workflow_desc="R02 echo workflow",
+            input_params={},
+            user_fields_keys=[],
+        )
+
+        with patch("openjiuwen.core.workflow.create_workflow_session",
+                   return_value=MagicMock()), \
+             patch.object(IRConverter, "async_ir_to_workflow", fake_async_ir_to_workflow):
+            results = await asyncio.gather(
+                adapter.invoke({"query": "R02_SESSION_A"}),
+                adapter.invoke({"query": "R02_SESSION_B"}),
+            )
+
+        # (1) 并发两调用各构建了一个 workflow 实例,不复用共享实例
+        assert len(created) == 2
+        assert created[0] is not created[1]
+
+        # (2) 输出与各自输入一一对应,不串线(发 A 不回 B)
+        assert results[0] == {"answer": "OK:R02_SESSION_A"}
+        assert results[1] == {"answer": "OK:R02_SESSION_B"}
+
+        # (3) 各实例只收到自己的 query,未被另一并发请求覆盖
+        queries_seen = {wf.received_inputs.get("query") for wf in created}
+        assert queries_seen == {"R02_SESSION_A", "R02_SESSION_B"}
+
+    @pytest.mark.asyncio
+    async def test_invoke_uses_ir_data_not_shared_instance(self):
+        """invoke 每次都调 async_ir_to_workflow(self._ir_data),不持有共享实例。"""
+        from agent_runtime.runner.react_workflow_adapter import ReactWorkflowAdapter
+        from jiuwen.serve.controllers.execution.ir_converter import IRConverter
+
+        async def fake_async_ir_to_workflow(ir_data, **kwargs):
+            assert ir_data == {"workflowId": "w-r02"}  # 传的是只读 ir_data
+            wf = _FakeWorkflow()
+            return wf
+
+        adapter = ReactWorkflowAdapter(
+            ir_data={"workflowId": "w-r02"},
+            card_id="card-r02",
+            workflow_name="wf",
+            workflow_desc="d",
+            input_params={},
+            user_fields_keys=[],
+        )
+
+        # adapter 实例上不应残留任何共享 workflow 实例属性
+        assert not hasattr(adapter, "_workflow_instance")
+
+        with patch("openjiuwen.core.workflow.create_workflow_session",
+                   return_value=MagicMock()), \
+             patch.object(IRConverter, "async_ir_to_workflow", fake_async_ir_to_workflow):
+            result = await adapter.invoke({"query": "X"})
+
+        assert result == {"answer": "OK:X"}
+
+    @pytest.mark.asyncio
+    async def test_failure_in_one_call_does_not_pollute_the_other(self):
+        """§9.3 异常隔离:一个调用 stream 抛错,不影响另一并发调用(独立实例+session)。"""
+        from agent_runtime.runner.react_workflow_adapter import ReactWorkflowAdapter
+        from jiuwen.serve.controllers.execution.ir_converter import IRConverter
+
+        async def fake_async_ir_to_workflow(ir_data, **kwargs):
+            return _FakeWorkflowMaybeFail()
+
+        adapter = ReactWorkflowAdapter(
+            ir_data={"workflowId": "w-r02"},
+            card_id="card-r02",
+            workflow_name="wf",
+            workflow_desc="d",
+            input_params={},
+            user_fields_keys=[],
+        )
+
+        with patch("openjiuwen.core.workflow.create_workflow_session",
+                   return_value=MagicMock()), \
+             patch.object(IRConverter, "async_ir_to_workflow", fake_async_ir_to_workflow):
+            results = await asyncio.gather(
+                adapter.invoke({"query": "FAIL"}),
+                adapter.invoke({"query": "OK"}),
+                return_exceptions=True,
+            )
+
+        # 失败调用抛错,成功调用不受污染、正常返回自己的答案
+        assert isinstance(results[0], Exception)
+        assert results[1] == {"answer": "OK:OK"}


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

<!-- Thanks for sending a pull request! Here are some tips for you: 1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/community/blob/master/CONTRIBUTING.md 2) If you want to contribute your code but don't know who will review and merge, please add label `openjiuwen-assistant` to the pull request, we will find and do it as soon as possible. -->
What type of PR is this?

/kind bug

Self-checklist:

 设计:PR对应的方案是否已经经过Maintainer评审,方案检视意见是否均已答复并完成方案修改
 测试:PR中的代码是否已有UT/ST测试用例进行充分的覆盖,新增测试用例是否随本PR一并上库或已经上库
 验证:PR描述信息中是否已包含对该PR对应的Feature、Refactor、Bugfix的预期目标达成情况的详细验证结果描述
 接口:是否涉及对外接口变更,相应变更已得到接口评审组织的通过,API对应的注释信息已经刷新正确
 文档:是否涉及官网文档修改,如果涉及请及时提交资料到Doc仓
修改内容(What changed and why)
问题
ReAct agent 上并发请求调用其工作流工具时,发生跨请求输出污染(发 A 回 B / 输出为 None / 输出残缺),用户可见。单 worker 进程下 100% 稳定复现(5/5),多 worker 下概率性(≈1/N)。严重性 P0(并发数据污染)。

根因
全局 Runner.resource_mgr 对每个 (tool_id, agent_id) 只存一个 ReactWorkflowAdapter(包一个 workflow 实例),所有并发请求解析到这同一个共享实例;该 workflow 实例在 compile() 阶段把运行态写到自身(self._session.set_session(session) / self._graph.compile(session, ...)),非并发安全 → 并发 stream() 在共享 self._session/self._graph 上竞写 → 输出串线/损坏。

注册表"先删后加覆盖"(注册层)与"输出串线"(执行层)是同一根因的两个症状。

涉及代码:

agent_runtime/runner/react_workflow_adapter.py:__init__ 持有共享 self._workflow_instance;invoke 复用 self._workflow_instance.stream(...)
agent_runtime/runner/react_agent_runner.py:注册到进程级单例 Runner.resource_mgr,key=(tool_id, agent_id),每请求先删后加
openjiuwen core/workflow/_workflow.py:compile() 写共享 self._session/self._graph(非本 PR 改动,见"残留")
修复方案(方案 A:per-call 实例隔离)
adapter 不再持有共享 workflow_instance,改存只读 ir_data: dict + card_id: str;invoke() 每次自建 LazyWorkflow(IRConverter.async_ir_to_workflow(self._ir_data)),各请求独立 _session/_graph,compile() 不再竞写。不引入锁,不降并发度(代价:每次工具调用重新构图,须压测,见"残留")。

react_workflow_adapter.py:__init__ 改收 ir_data+card_id(取 ToolCard.id);invoke 每次自建 wf_instance 后 stream;删去不再使用的 Any import
react_agent_runner.py 注册点:传 ir_data=sub_ir + card_id=wf_instance.card.id 替代 workflow_instance=wf_instance
改动清单
文件	改动	性质
agent_runtime/runner/react_workflow_adapter.py	__init__ 收 ir_data+card_id;invoke 每次自建 LazyWorkflow;删 Any import	P0 核心修复
agent_runtime/runner/react_agent_runner.py	注册点传 sub_ir+card_id 替代 wf_instance	配套注册点
tests/unit_tests/runner/test_react_workflow_adapter_concurrency.py	adapter 并发隔离 + 异常隔离单测	新增 UT
tests/unit_tests/runner/test_ir_concurrent_build_immutability.py	IR 并发构建不变性单测	新增 UT
两处生产改动 surgical(最小 diff),不改协议、不改事件流、不改 checkpoint,跨 agent-runtime 应用码,重启即生效。

如何测试 / 验证(How to test / verify)
UT(随本 PR 上库,5/5 通过)

tests/unit_tests/runner/test_react_workflow_adapter_concurrency.py
  test_concurrent_invokes_build_separate_instances_and_do_not_cross   # §9.1 并发隔离
  test_invoke_uses_ir_data_not_shared_instance                        # §9.1 不持共享实例
  test_failure_in_one_call_does_not_pollute_the_other                 # §9.3 异常隔离
tests/unit_tests/runner/test_ir_concurrent_build_immutability.py
  test_concurrent_build_leaves_ir_unchanged_and_yields_distinct_instances  # §9.2 IR 并发不变性
  test_single_ir_repeated_build_is_stable                                  # §9.2 顺序构建稳定
复现/运行:


cd agent-runtime
uv sync --extra dev
.venv/bin/python -m pytest tests/unit_tests/runner/test_react_workflow_adapter_concurrency.py \
                             tests/unit_tests/runner/test_ir_concurrent_build_immutability.py
# 结果:5 passed
E2E 并发回归(运行态实证)
复现条件:GUNICORN_WORK_NUM=1(单 worker,bug 原 100% 必现条件)+ 同 agent、不同 conversationId、不同 query、错峰 0.3s 并发两请求。fixture:R02_ROOT_ReAct_Agent(echo workflow:Start query → End R02_E2E_OK: {{query}},正确应原样回显 query)。


# A: query=R02_SESSION_A;B: query=R02_SESSION_B,错峰 0.3s
curl -s -k -N -X POST https://127.0.0.1:8000/v1/orchestration/ir/execute \
  -H 'Content-Type: application/json' \
  -d '{"conversationId":"r02-A-1","userId":"r02-tester",
       "irPath":"agent/ir/923c547c-39d3-47a9-a19b-275ce64114ab/923c547c-39d3-47a9-a19b-275ce64114ab.json",
       "query":"R02_SESSION_A","responseMode":"streaming"}' > /tmp/r02_A.out &
sleep 0.3
curl -s -k -N -X POST https://127.0.0.1:8000/v1/orchestration/ir/execute \
  -H 'Content-Type: application/json' \
  -d '{"conversationId":"r02-B-1","userId":"r02-tester",
       "irPath":"agent/ir/923c547c-39d3-47a9-a19b-275ce64114ab/923c547c-39d3-47a9-a19b-275ce64114ab.json",
       "query":"R02_SESSION_B","responseMode":"streaming"}' > /tmp/r02_B.out &
wait
# 抽取各方 workflow 工具 outputs.answer,断言 A→R02_SESSION_A、B→R02_SESSION_B
验证结果(5 轮):

轮次	A 工具输出	B 工具输出	结果
R1	R02_SESSION_A	R02_SESSION_B	✓ 不串线
R2	R02_SESSION_A	R02_SESSION_B	✓ 不串线
R3	R02_SESSION_A	R02_SESSION_B	✓ 不串线
R4	R02_SESSION_A	R02_SESSION_B	✓ 不串线
R5	R02_SESSION_A	R02_SESSION_B	✓ 不串线
修复前对比(同样单 worker + 错峰 0.3s,5/5 全串线/损坏):发 A 回 B、A 拿到 B 的、B 拿到 A 的、None、输出残缺。

运行时探针(PROBE2)钉死根因:id(self)/id(self._workflow_instance) 在并发两请求相同(共享实例),in_query 各对各的、out_answer 坏。修复后仍可同(共享 adapter),但 wf_instance 各请求独立——以行为正确为准。

是否涉及对外接口变更
不涉及。ReactWorkflowAdapter 是 agent-runtime 内部适配器,非对外 API;/v1/orchestration/ir/execute 契约、事件流、checkpoint 均未变。

是否涉及官网文档修改
不涉及。无用户可见行为变更(只是修正了并发污染,正常单请求行为不变)。

是否涉及依赖的三方库变更
不涉及。纯应用码改动,无新增/变更依赖。

是否前向兼容
是。ReactWorkflowAdapter.__init__ 参数从 workflow_instance 改为 ir_data+card_id,调用方仅 react_agent_runner.py 一处,已同步修改;无其它调用方(grep 确认仅 2 处引用:类定义 + 注册点)。无序列化/持久化字段变更。