### PR TITLE
feat(manager): 异步任务管理与运行逻辑从runtime迁移至manager模块

### DIFF
--- a/backend/studio-manager-api/src/main/java/com/openjiuwen/studio/agent/manager/controller/ConversationHistoryApi.java
+++ b/backend/studio-manager-api/src/main/java/com/openjiuwen/studio/agent/manager/controller/ConversationHistoryApi.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026-2026. All rights reserved.
+ */
+
+package com.openjiuwen.studio.agent.manager.controller;
+
+import com.openjiuwen.studio.agent.common.dto.ErrorRsp;
+import com.openjiuwen.studio.agent.common.dto.agent.Message;
+import com.openjiuwen.studio.agent.common.dto.run.ConversationDeleteResp;
+import com.openjiuwen.studio.agent.common.dto.run.RetrieveConversationQo;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@Api(value = "ConversationHistory", description = "the ConversationHistory API")
+@Validated
+public interface ConversationHistoryApi {
+
+    @ApiOperation(value = "根据conversation_id删除会话", nickname = "deleteConversationHistory",
+        notes = "根据conversation_id删除会话", response = ConversationDeleteResp.class,
+        tags = {"ConversationManagement"})
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "", response = ConversationDeleteResp.class),
+        @ApiResponse(code = 400, message = "Bad Request 请求错误", response = ErrorRsp.class),
+        @ApiResponse(code = 401, message = "Unauthorized 鉴权失败", response = String.class),
+        @ApiResponse(code = 403, message = "Forbidden 没有操作权限", response = ErrorRsp.class),
+        @ApiResponse(code = 404, message = "Not Found 找不到资源", response = ErrorRsp.class),
+        @ApiResponse(code = 500, message = "Internal Server Error 服务内部错误", response = ErrorRsp.class)
+    })
+    @RequestMapping(value = "/v1/{project_id}/agent-manager/agents/{agent_id}/conversations/{conversation_id}/history",
+        produces = {"application/json"}, method = RequestMethod.DELETE)
+    ResponseEntity<ConversationDeleteResp> deleteConversationHistory(
+        @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(max = 64)
+        @Parameter(in = ParameterIn.PATH, description = "租户项目id", required = true, schema = @Schema())
+        @PathVariable("project_id") String projectId,
+        @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(max = 64)
+        @Parameter(in = ParameterIn.PATH, description = "workflow/agent id", required = true, schema = @Schema())
+        @PathVariable("agent_id") String agentId,
+        @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(max = 64)
+        @Parameter(in = ParameterIn.PATH, description = "conversation_id", required = true, schema = @Schema())
+        @PathVariable("conversation_id") String conversationId,
+        @Size(max = 32) @ApiParam(value = "版本号") @RequestParam(value = "version_id", required = false)
+        String versionId,
+        @Pattern(regexp = "^[a-zA-Z0-9_()\\-]+$") @Size(min = 1, max = 64) @ApiParam(value = "项目空间id")
+        @RequestParam(value = "workspace_id", required = false) String workspaceId);
+
+    @ApiOperation(value = "根据conversation_id查询会话", nickname = "retrieveConversationHistory",
+        notes = "根据conversation_id查询会话", response = Message.class, responseContainer = "List",
+        tags = {"ConversationManagement"})
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "conversation消息", response = Message.class, responseContainer = "List"),
+        @ApiResponse(code = 400, message = "Bad Request 请求错误", response = ErrorRsp.class),
+        @ApiResponse(code = 401, message = "Unauthorized 鉴权失败", response = String.class),
+        @ApiResponse(code = 403, message = "Forbidden 没有操作权限", response = ErrorRsp.class),
+        @ApiResponse(code = 404, message = "Not Found 找不到资源", response = ErrorRsp.class),
+        @ApiResponse(code = 500, message = "Internal Server Error 服务内部错误", response = ErrorRsp.class)
+    })
+    @RequestMapping(value = "/v1/{project_id}/agent-manager/agents/{agent_id}/conversations/{conversation_id}/history",
+        produces = {"application/json"}, method = RequestMethod.GET)
+    ResponseEntity<List<Message>> retrieveConversationHistory(
+        @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(max = 64)
+        @Parameter(in = ParameterIn.PATH, description = "租户项目id", required = true, schema = @Schema())
+        @PathVariable("project_id") String projectId,
+        @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(max = 64)
+        @Parameter(in = ParameterIn.PATH, description = "workflow/agent id", required = true, schema = @Schema())
+        @PathVariable("agent_id") String agentId,
+        @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(max = 64)
+        @Parameter(in = ParameterIn.PATH, description = "conversation_id", required = true, schema = @Schema())
+        @PathVariable("conversation_id") String conversationId,
+        @ApiParam(value = "RetrieveConversationQo: converted from multi query params") @Valid
+        RetrieveConversationQo retrieveConversationQo,
+        @Pattern(regexp = "^[a-zA-Z0-9_()\\-]+$") @Size(min = 1, max = 64) @ApiParam(value = "项目空间id")
+        @RequestParam(value = "workspace_id", required = false) String workspaceId);
+}

--- a/backend/studio-manager-api/src/main/java/com/openjiuwen/studio/agent/manager/controller/ConversationHistoryApiController.java
+++ b/backend/studio-manager-api/src/main/java/com/openjiuwen/studio/agent/manager/controller/ConversationHistoryApiController.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026-2026. All rights reserved.
+ */
+
+package com.openjiuwen.studio.agent.manager.controller;
+
+import com.openjiuwen.studio.agent.common.dto.agent.Message;
+import com.openjiuwen.studio.agent.common.dto.run.ConversationDeleteResp;
+import com.openjiuwen.studio.agent.common.dto.run.RetrieveConversationQo;
+import com.openjiuwen.studio.agent.common.utils.ResponseModel;
+import com.openjiuwen.studio.agent.manager.service.IConversationHistoryService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * ConversationHistory controller
+ */
+@RestController
+public class ConversationHistoryApiController implements ConversationHistoryApi {
+    private static final Logger log = LoggerFactory.getLogger(ConversationHistoryApiController.class);
+
+    @Autowired
+    private IConversationHistoryService conversationHistoryService;
+
+    @Override
+    public ResponseEntity<ConversationDeleteResp> deleteConversationHistory(
+            String projectId, String agentId, String conversationId,
+            String versionId, String workspaceId) {
+        return ResponseModel.success(
+            conversationHistoryService.deleteConversationHistory(projectId, agentId, conversationId, versionId, workspaceId));
+    }
+
+    @Override
+    public ResponseEntity<List<Message>> retrieveConversationHistory(
+            String projectId, String agentId, String conversationId,
+            RetrieveConversationQo retrieveConversationQo, String workspaceId) {
+        return ResponseModel.success(
+            conversationHistoryService.retrieveConversationHistory(projectId, agentId, conversationId, retrieveConversationQo, workspaceId));
+    }
+}

--- a/backend/studio-manager-api/src/main/java/com/openjiuwen/studio/agent/manager/controller/TaskManagementApi.java
+++ b/backend/studio-manager-api/src/main/java/com/openjiuwen/studio/agent/manager/controller/TaskManagementApi.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026-2026. All rights reserved.
+ */
+
+package com.openjiuwen.studio.agent.manager.controller;
+
+import com.openjiuwen.studio.agent.common.dto.ErrorRsp;
+import com.openjiuwen.studio.agent.common.dto.run.CancelTaskRsp;
+import com.openjiuwen.studio.agent.common.dto.run.CreateTaskReq;
+import com.openjiuwen.studio.agent.common.dto.run.ListTaskQo;
+import com.openjiuwen.studio.agent.common.dto.run.ModifyTaskReq;
+import com.openjiuwen.studio.agent.common.dto.run.ResumeTaskReq;
+import com.openjiuwen.studio.agent.common.dto.run.TaskListRsp;
+import com.openjiuwen.studio.agent.common.dto.run.TaskRsp;
+import com.openjiuwen.studio.agent.manager.dto.CommonDeleteRsp;
+import com.openjiuwen.studio.agent.common.dto.run.RetrieveTaskQo;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Api(value = "TaskManagement", description = "the TaskManagement API")
+@Validated
+
+/**
+ * TaskManagementApi interface
+ */
+public interface TaskManagementApi {
+    @ApiOperation(value = "取消异步任务详情", nickname = "cancelTask", notes = "", response = CancelTaskRsp.class,
+        tags = {"TaskManagement"})
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "", response = CancelTaskRsp.class),
+        @ApiResponse(code = 400, message = "", response = ErrorRsp.class)
+    })
+    @RequestMapping(value = "/v1/{project_id}/agent-manager/workflows/{workflow_id}/tasks/{task_id}/cancel",
+        produces = {"application/json"}, method = RequestMethod.DELETE)
+    ResponseEntity<CancelTaskRsp> cancelTask(@Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
+        @Parameter(in = ParameterIn.PATH, description = "租户项目id", required = true, schema = @Schema())
+        @PathVariable("project_id") String projectId, @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
+        @Parameter(in = ParameterIn.PATH, description = "工作流id", required = true, schema = @Schema())
+        @PathVariable("workflow_id") String workflowId, @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
+        @Parameter(in = ParameterIn.PATH, description = "异步任务id", required = true, schema = @Schema())
+        @PathVariable("task_id") String taskId,
+        @Pattern(regexp = "^[a-zA-Z0-9_()\\-]+$") @Size(min = 1, max = 64) @ApiParam(value = "项目空间id")
+        @RequestParam(value = "workspace_id", required = false) String workspaceId);
+
+    @ApiOperation(value = "提交异步工作流任务", nickname = "createTask", notes = "", response = TaskRsp.class,
+        tags = {"TaskManagement"})
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "", response = TaskRsp.class),
+        @ApiResponse(code = 400, message = "", response = ErrorRsp.class)
+    })
+    @RequestMapping(value = "/v1/{project_id}/agent-manager/workflows/{workflow_id}/tasks", produces = {"application/json"},
+        consumes = {"application/json"}, method = RequestMethod.POST)
+    ResponseEntity<TaskRsp> createTask(@Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
+        @Parameter(in = ParameterIn.PATH, description = "租户项目id", required = true, schema = @Schema())
+        @PathVariable("project_id") String projectId, @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
+        @Parameter(in = ParameterIn.PATH, description = "工作流id", required = true, schema = @Schema())
+        @PathVariable("workflow_id") String workflowId,
+        @Size(max = 64) @ApiParam(value = "版本号") @RequestParam(value = "version", required = false) String version,
+        @Pattern(regexp = "^[a-zA-Z0-9_()\\-]+$") @Size(min = 1, max = 64) @ApiParam(value = "项目空间id")
+        @RequestParam(value = "workspace_id", required = false) String workspaceId,
+        @NotNull @ApiParam(value = "创建文件请求体", required = true) @Valid @RequestBody CreateTaskReq body);
+
+    @ApiOperation(value = "取消异步任务详情", nickname = "deleteTask", notes = "", response = CommonDeleteRsp.class,
+        tags = {"TaskManagement"})
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "", response = CommonDeleteRsp.class),
+        @ApiResponse(code = 400, message = "", response = ErrorRsp.class)
+    })
+    @RequestMapping(value = "/v1/{project_id}/agent-manager/workflows/{workflow_id}/tasks/{task_id}", produces = {"application/json"},
+        method = RequestMethod.DELETE)
+    ResponseEntity<CommonDeleteRsp> deleteTask(@Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
+        @Parameter(in = ParameterIn.PATH, description = "租户项目id", required = true, schema = @Schema())
+        @PathVariable("project_id") String projectId, @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
+        @Parameter(in = ParameterIn.PATH, description = "工作流id", required = true, schema = @Schema())
+        @PathVariable("workflow_id") String workflowId, @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
+        @Parameter(in = ParameterIn.PATH, description = "异步任务id", required = true, schema = @Schema())
+        @PathVariable("task_id") String taskId,
+        @Pattern(regexp = "^[a-zA-Z0-9_()\\-]+$") @Size(min = 1, max = 64) @ApiParam(value = "项目空间id")
+        @RequestParam(value = "workspace_id", required = false) String workspaceId);
+
+    @ApiOperation(value = "查看任务列表", nickname = "listTask", notes = "", response = TaskListRsp.class,
+        tags = {"TaskManagement"})
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "", response = TaskListRsp.class),
+        @ApiResponse(code = 400, message = "", response = ErrorRsp.class)
+    })
+    @RequestMapping(value = "/v1/{project_id}/agent-manager/workflows/{workflow_id}/tasks", produces = {"application/json"},
+        method = RequestMethod.GET)
+    ResponseEntity<TaskListRsp> listTask(@Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
+        @Parameter(in = ParameterIn.PATH, description = "租户项目id", required = true, schema = @Schema())
+        @PathVariable("project_id") String projectId, @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
+        @Parameter(in = ParameterIn.PATH, description = "工作流id", required = true, schema = @Schema())
+        @PathVariable("workflow_id") String workflowId,
+        @ApiParam(value = "ListTaskQo: converted from multi query params") @Valid ListTaskQo listTaskQo);
+
+    @ApiOperation(value = "修改任务信息", nickname = "modifyTask", notes = "", response = TaskRsp.class,
+        tags = {"TaskManagement"})
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "", response = TaskRsp.class),
+        @ApiResponse(code = 400, message = "", response = ErrorRsp.class)
+    })
+    @RequestMapping(value = "/v1/{project_id}/agent-manager/workflows/{workflow_id}/tasks/{task_id}", produces = {"application/json"},
+        consumes = {"application/json"}, method = RequestMethod.PUT)
+    ResponseEntity<TaskRsp> modifyTask(@Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
+        @Parameter(in = ParameterIn.PATH, description = "租户项目id", required = true, schema = @Schema())
+        @PathVariable("project_id") String projectId, @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
+        @Parameter(in = ParameterIn.PATH, description = "工作流id", required = true, schema = @Schema())
+        @PathVariable("workflow_id") String workflowId, @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
+        @Parameter(in = ParameterIn.PATH, description = "异步任务id", required = true, schema = @Schema())
+        @PathVariable("task_id") String taskId,
+        @Pattern(regexp = "^[a-zA-Z0-9_()\\-]+$") @Size(min = 1, max = 64) @ApiParam(value = "项目空间id")
+        @RequestParam(value = "workspace_id", required = false) String workspaceId,
+        @NotNull @ApiParam(value = "创建文件请求体", required = true) @Valid @RequestBody ModifyTaskReq body);
+
+    @ApiOperation(value = "继续执行任务", nickname = "resumeTask", notes = "", response = TaskRsp.class,
+        tags = {"TaskManagement"})
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "", response = TaskRsp.class),
+        @ApiResponse(code = 400, message = "", response = ErrorRsp.class)
+    })
+    @RequestMapping(value = "/v1/{project_id}/agent-manager/workflows/{workflow_id}/tasks/{task_id}", produces = {"application/json"},
+        consumes = {"application/json"}, method = RequestMethod.POST)
+    ResponseEntity<TaskRsp> resumeTask(@Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
+        @Parameter(in = ParameterIn.PATH, description = "租户项目id", required = true, schema = @Schema())
+        @PathVariable("project_id") String projectId, @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
+        @Parameter(in = ParameterIn.PATH, description = "工作流id", required = true, schema = @Schema())
+        @PathVariable("workflow_id") String workflowId, @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
+        @Parameter(in = ParameterIn.PATH, description = "异步任务id", required = true, schema = @Schema())
+        @PathVariable("task_id") String taskId,
+        @Pattern(regexp = "^[a-zA-Z0-9_()\\-]+$") @Size(min = 1, max = 64) @ApiParam(value = "项目空间id")
+        @RequestParam(value = "workspace_id", required = false) String workspaceId,
+        @NotNull @ApiParam(value = "创建文件请求体", required = true) @Valid @RequestBody ResumeTaskReq body);
+
+    @ApiOperation(value = "获取异步任务详情", nickname = "retrieveTask", notes = "", response = TaskRsp.class,
+        tags = {"TaskManagement"})
+    @ApiResponses(value = {
+        @ApiResponse(code = 200, message = "", response = TaskRsp.class),
+        @ApiResponse(code = 400, message = "", response = ErrorRsp.class)
+    })
+    @RequestMapping(value = "/v1/{project_id}/agent-manager/workflows/{workflow_id}/tasks/{task_id}", produces = {"application/json"},
+        method = RequestMethod.GET)
+    ResponseEntity<TaskRsp> retrieveTask(@Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
+        @Parameter(in = ParameterIn.PATH, description = "租户项目id", required = true, schema = @Schema())
+        @PathVariable("project_id") String projectId, @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
+        @Parameter(in = ParameterIn.PATH, description = "工作流id", required = true, schema = @Schema())
+        @PathVariable("workflow_id") String workflowId, @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
+        @Parameter(in = ParameterIn.PATH, description = "异步任务id", required = true, schema = @Schema())
+        @PathVariable("task_id") String taskId,
+        @ApiParam(value = "RetrieveTaskQo: converted from multi query params") @Valid RetrieveTaskQo retrieveTaskQo);
+
+}

--- a/backend/studio-manager-api/src/main/java/com/openjiuwen/studio/agent/manager/controller/TaskManagementApiController.java
+++ b/backend/studio-manager-api/src/main/java/com/openjiuwen/studio/agent/manager/controller/TaskManagementApiController.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026-2026. All rights reserved.
+ */
+
+package com.openjiuwen.studio.agent.manager.controller;
+
+import com.openjiuwen.studio.agent.common.dto.run.CancelTaskRsp;
+import com.openjiuwen.studio.agent.common.dto.run.CreateTaskReq;
+import com.openjiuwen.studio.agent.common.dto.run.ListTaskQo;
+import com.openjiuwen.studio.agent.common.dto.run.ModifyTaskReq;
+import com.openjiuwen.studio.agent.common.dto.run.ResumeTaskReq;
+import com.openjiuwen.studio.agent.common.dto.run.TaskListRsp;
+import com.openjiuwen.studio.agent.common.dto.run.TaskRsp;
+import com.openjiuwen.studio.agent.common.utils.ResponseModel;
+import com.openjiuwen.studio.agent.manager.dto.CommonDeleteRsp;
+import com.openjiuwen.studio.agent.common.dto.run.RetrieveTaskQo;
+import com.openjiuwen.studio.agent.manager.service.ITaskManagementService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * TaskManagement controller
+ */
+@RestController
+
+public class TaskManagementApiController implements TaskManagementApi {
+    private static final Logger log = LoggerFactory.getLogger(TaskManagementApiController.class);
+
+    @Autowired
+    private ITaskManagementService taskManagementService;
+
+    @Override
+    public ResponseEntity<CancelTaskRsp> cancelTask(String projectId, String workflowId, String taskId, String workspaceId) {
+        return ResponseModel.success(taskManagementService.cancelTask(projectId, workflowId, taskId, workspaceId));
+    }
+
+    @Override
+    public ResponseEntity<TaskRsp> createTask(String projectId, String workflowId, String version, String workspaceId, CreateTaskReq body) {
+        return ResponseModel.success(taskManagementService.createTask(projectId, workflowId, version, workspaceId, body));
+    }
+
+    @Override
+    public ResponseEntity<CommonDeleteRsp> deleteTask(String projectId, String workflowId, String taskId, String workspaceId) {
+        return ResponseModel.success(taskManagementService.deleteTask(projectId, workflowId, taskId, workspaceId));
+    }
+
+    @Override
+    public ResponseEntity<TaskListRsp> listTask(String projectId, String workflowId, ListTaskQo listTaskQo) {
+        return ResponseModel.success(taskManagementService.listTask(projectId, workflowId, listTaskQo));
+    }
+
+    @Override
+    public ResponseEntity<TaskRsp> modifyTask(String projectId, String workflowId, String taskId, String workspaceId, ModifyTaskReq body) {
+        return ResponseModel.success(taskManagementService.modifyTask(projectId, workflowId, taskId, workspaceId, body));
+    }
+
+    @Override
+    public ResponseEntity<TaskRsp> resumeTask(String projectId, String workflowId, String taskId, String workspaceId, ResumeTaskReq body) {
+        return ResponseModel.success(taskManagementService.resumeTask(projectId, workflowId, taskId, workspaceId, body));
+    }
+
+    @Override
+    public ResponseEntity<TaskRsp> retrieveTask(String projectId, String workflowId, String taskId, RetrieveTaskQo retrieveTaskQo) {
+        return ResponseModel.success(taskManagementService.retrieveTask(projectId, workflowId, taskId, retrieveTaskQo));
+    }
+}

--- a/backend/studio-manager-api/src/main/java/com/openjiuwen/studio/agent/manager/service/IConversationHistoryService.java
+++ b/backend/studio-manager-api/src/main/java/com/openjiuwen/studio/agent/manager/service/IConversationHistoryService.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026-2026. All rights reserved.
+ */
+
+package com.openjiuwen.studio.agent.manager.service;
+
+import com.openjiuwen.studio.agent.common.dto.agent.Message;
+import com.openjiuwen.studio.agent.common.dto.run.ConversationDeleteResp;
+import com.openjiuwen.studio.agent.common.dto.run.RetrieveConversationQo;
+
+import java.util.List;
+
+/**
+ * ConversationHistory service
+ */
+public interface IConversationHistoryService {
+
+    ConversationDeleteResp deleteConversationHistory(String projectId, String agentId,
+        String conversationId, String versionId, String workspaceId);
+
+    List<Message> retrieveConversationHistory(String projectId, String agentId,
+        String conversationId, RetrieveConversationQo retrieveConversationQo, String workspaceId);
+}

--- a/backend/studio-manager-api/src/main/java/com/openjiuwen/studio/agent/manager/service/ITaskManagementService.java
+++ b/backend/studio-manager-api/src/main/java/com/openjiuwen/studio/agent/manager/service/ITaskManagementService.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026-2026. All rights reserved.
+ */
+
+package com.openjiuwen.studio.agent.manager.service;
+
+import com.openjiuwen.studio.agent.common.dto.run.CancelTaskRsp;
+import com.openjiuwen.studio.agent.common.dto.run.CreateTaskReq;
+import com.openjiuwen.studio.agent.common.dto.run.ListTaskQo;
+import com.openjiuwen.studio.agent.common.dto.run.ModifyTaskReq;
+import com.openjiuwen.studio.agent.common.dto.run.ResumeTaskReq;
+import com.openjiuwen.studio.agent.common.dto.run.TaskListRsp;
+import com.openjiuwen.studio.agent.common.dto.run.TaskRsp;
+import com.openjiuwen.studio.agent.manager.dto.CommonDeleteRsp;
+import com.openjiuwen.studio.agent.common.dto.run.RetrieveTaskQo;
+
+/**
+ * TaskManagement service
+ */
+public interface ITaskManagementService {
+    /**
+     * cancelTask
+     *
+     * @param projectId projectId
+     * @param workflowId workflowId
+     * @param taskId taskId
+     * @param workspaceId workspaceId
+     */
+    CancelTaskRsp cancelTask(String projectId, String workflowId, String taskId, String workspaceId);
+
+    /**
+     * createTask
+     *
+     * @param projectId projectId
+     * @param workflowId workflowId
+     * @param version version
+     * @param workspaceId workspaceId
+     * @param body body
+     */
+    TaskRsp createTask(String projectId, String workflowId, String version, String workspaceId, CreateTaskReq body);
+
+    /**
+     * deleteTask
+     *
+     * @param projectId projectId
+     * @param workflowId workflowId
+     * @param taskId taskId
+     * @param workspaceId workspaceId
+     */
+    CommonDeleteRsp deleteTask(String projectId, String workflowId, String taskId, String workspaceId);
+
+    /**
+     * listTask
+     *
+     * @param projectId projectId
+     * @param workflowId workflowId
+     * @param listTaskQo listTaskQo
+     */
+    TaskListRsp listTask(String projectId, String workflowId, ListTaskQo listTaskQo);
+
+    /**
+     * modifyTask
+     *
+     * @param projectId projectId
+     * @param workflowId workflowId
+     * @param taskId taskId
+     * @param workspaceId workspaceId
+     * @param body body
+     */
+    TaskRsp modifyTask(String projectId, String workflowId, String taskId, String workspaceId, ModifyTaskReq body);
+
+    /**
+     * resumeTask
+     *
+     * @param projectId projectId
+     * @param workflowId workflowId
+     * @param taskId taskId
+     * @param workspaceId workspaceId
+     * @param body body
+     */
+    TaskRsp resumeTask(String projectId, String workflowId, String taskId, String workspaceId, ResumeTaskReq body);
+
+    /**
+     * retrieveTask
+     *
+     * @param projectId projectId
+     * @param workflowId workflowId
+     * @param taskId taskId
+     * @param retrieveTaskQo retrieveTaskQo
+     */
+    TaskRsp retrieveTask(String projectId, String workflowId, String taskId, RetrieveTaskQo retrieveTaskQo);
+}

--- a/backend/studio-manager-service/src/main/java/com/openjiuwen/studio/agent/manager/controller/AgentServiceProxyController.java
+++ b/backend/studio-manager-service/src/main/java/com/openjiuwen/studio/agent/manager/controller/AgentServiceProxyController.java
@@ -28,9 +28,7 @@ import com.openjiuwen.studio.agent.common.dto.run.AdditionalQuestionsWorkflowReq
 import com.openjiuwen.studio.agent.common.dto.run.AgentExecutionQueries;
 import com.openjiuwen.studio.agent.common.dto.run.AsrReq;
 import com.openjiuwen.studio.agent.common.dto.run.AsrRsp;
-import com.openjiuwen.studio.agent.common.dto.run.CancelTaskRsp;
 import com.openjiuwen.studio.agent.common.dto.run.ConversationDeleteResp;
-import com.openjiuwen.studio.agent.common.dto.run.CreateTaskReq;
 import com.openjiuwen.studio.agent.common.dto.run.GetAgentExecutionInfoQo;
 import com.openjiuwen.studio.agent.common.dto.run.GetControllerExecutionDetailQo;
 import com.openjiuwen.studio.agent.common.dto.run.GetExecutionInsightQo;
@@ -39,16 +37,10 @@ import com.openjiuwen.studio.agent.common.dto.run.ListAgentExecutionQueriesQo;
 import com.openjiuwen.studio.agent.common.dto.run.ListControllerExecutionsQo;
 import com.openjiuwen.studio.agent.common.dto.run.ListConversationQueriesQo;
 import com.openjiuwen.studio.agent.common.dto.run.ListExecutionQueriesQo;
-import com.openjiuwen.studio.agent.common.dto.run.ListTaskQo;
-import com.openjiuwen.studio.agent.common.dto.run.ModifyTaskReq;
 import com.openjiuwen.studio.agent.common.dto.run.ResetUserVariableMemoryResponseBody;
-import com.openjiuwen.studio.agent.common.dto.run.ResumeTaskReq;
 import com.openjiuwen.studio.agent.common.dto.run.RetrieveConversationMemoryQo;
 import com.openjiuwen.studio.agent.common.dto.run.RetrieveConversationQo;
-import com.openjiuwen.studio.agent.common.dto.run.RetrieveTaskQo;
 import com.openjiuwen.studio.agent.common.dto.run.RunToolRequestBody;
-import com.openjiuwen.studio.agent.common.dto.run.TaskListRsp;
-import com.openjiuwen.studio.agent.common.dto.run.TaskRsp;
 import com.openjiuwen.studio.agent.common.dto.tool.RunToolResponseBody;
 import com.openjiuwen.studio.agent.common.entity.Text2AudioReq;
 import com.openjiuwen.studio.agent.common.enums.StudioError;
@@ -61,7 +53,6 @@ import com.openjiuwen.studio.agent.manager.constant.CommonConstant;
 import com.openjiuwen.studio.agent.manager.dto.AgentRunReq;
 import com.openjiuwen.studio.agent.manager.dto.AutoAddResultJsonObject;
 import com.openjiuwen.studio.agent.manager.dto.BatchDeleteUserVariableMemoryRequestBody;
-import com.openjiuwen.studio.agent.manager.dto.CommonDeleteRsp;
 import com.openjiuwen.studio.agent.manager.dto.MemoryVariable;
 import com.openjiuwen.studio.agent.manager.dto.ServiceRunAgentReq;
 import com.openjiuwen.studio.agent.manager.dto.ServiceWorkflowRunReq;
@@ -873,207 +864,11 @@ public class AgentServiceProxyController {
         return workflowRuntimeService.getExecutionInsight(projectId, workflowId, executionId, getExecutionInsightQo);
     }
 
-    @ApiOperation(value = "根据conversation_id删除会话", nickname = "deleteConversation",
-        notes = "根据conversation_id删除会话", response = ConversationDeleteResp.class,
-        tags = {"ConversationManagement"})
-    @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "", response = ConversationDeleteResp.class),
-        @ApiResponse(code = 400, message = "Bad Request 请求错误", response = ErrorRsp.class),
-        @ApiResponse(code = 401, message = "Unauthorized 鉴权失败", response = String.class),
-        @ApiResponse(code = 403, message = "Forbidden 没有操作权限", response = ErrorRsp.class),
-        @ApiResponse(code = 404, message = "Not Found 找不到资源", response = ErrorRsp.class),
-        @ApiResponse(code = 500, message = "Internal Server Error 服务内部错误", response = ErrorRsp.class)
-    })
-    @RequestMapping(value = "/v1/{project_id}/agent-manager/agents/{agent_id}/conversations/{conversation_id}/history",
-        produces = {"application/json"}, method = RequestMethod.DELETE)
-    public ConversationDeleteResp deleteConversation(@Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(max = 64)
-        @Parameter(in = ParameterIn.PATH, description = "租户项目id", required = true, schema = @Schema())
-        @PathVariable("project_id") String projectId, @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(max = 64)
-        @Parameter(in = ParameterIn.PATH, description = "workflow/agent id", required = true, schema = @Schema())
-        @PathVariable("agent_id") String agentId, @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(max = 64)
-        @Parameter(in = ParameterIn.PATH, description = "conversation_id", required = true, schema = @Schema())
-        @PathVariable("conversation_id") String conversationId,
-        @Size(max = 32) @ApiParam(value = "版本号") @RequestParam(value = "version_id", required = false)
-        String versionId, @RequestParam(value = "workspace_id", required = false) String workspaceId) {
 
-        return agentServiceProxyService.deleteConversation(projectId, agentId, conversationId, versionId, workspaceId)
-            .getBody();
-    }
 
-    @ApiOperation(value = "提交异步工作流任务", nickname = "createTask", notes = "", response = TaskRsp.class,
-        tags = {"TaskManagement"})
-    @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "", response = TaskRsp.class),
-        @ApiResponse(code = 400, message = "", response = ErrorRsp.class)
-    })
-    @RequestMapping(value = "/v1/{project_id}/agent-manager/workflows/{workflow_id}/tasks",
-        produces = {"application/json"}, consumes = {"application/json"}, method = RequestMethod.POST)
-    public TaskRsp createTask(@Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
-        @Parameter(in = ParameterIn.PATH, description = "租户项目id", required = true, schema = @Schema())
-        @PathVariable("project_id") String projectId, @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
-        @Parameter(in = ParameterIn.PATH, description = "工作流id", required = true, schema = @Schema())
-        @PathVariable("workflow_id") String workflowId,
-        @Size(max = 64) @ApiParam(value = "版本号") @RequestParam(value = "version", required = false) String version,
-        @Pattern(regexp = "^[a-zA-Z0-9_()\\-]+$") @Size(min = 1, max = 64) @ApiParam(value = "项目空间id")
-        @RequestParam(value = "workspace_id", required = false) String workspaceId,
-        @NotNull @ApiParam(value = "创建文件请求体", required = true) @Valid @RequestBody CreateTaskReq body) {
 
-        return agentServiceProxyService.createTask(projectId, workflowId, version, workspaceId, body).getBody();
-    }
 
-    @ApiOperation(value = "根据conversation_id查询会话", nickname = "retrieveConversation",
-        notes = "根据conversation_id查询会话", response = Message.class, responseContainer = "List",
-        tags = {"ConversationManagement"})
-    @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "conversation消息", response = Message.class, responseContainer = "List"),
-        @ApiResponse(code = 400, message = "Bad Request 请求错误", response = ErrorRsp.class),
-        @ApiResponse(code = 401, message = "Unauthorized 鉴权失败", response = String.class),
-        @ApiResponse(code = 403, message = "Forbidden 没有操作权限", response = ErrorRsp.class),
-        @ApiResponse(code = 404, message = "Not Found 找不到资源", response = ErrorRsp.class),
-        @ApiResponse(code = 500, message = "Internal Server Error 服务内部错误", response = ErrorRsp.class)
-    })
-    @RequestMapping(value = "/v1/{project_id}/agent-manager/agents/{agent_id}/conversations/{conversation_id}/history",
-        produces = {"application/json"}, method = RequestMethod.GET)
-    public List<Message> retrieveConversation(@Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(max = 64)
-        @Parameter(in = ParameterIn.PATH, description = "租户项目id", required = true, schema = @Schema())
-        @PathVariable("project_id") String projectId, @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(max = 64)
-        @Parameter(in = ParameterIn.PATH, description = "workflow/agent id", required = true, schema = @Schema())
-        @PathVariable("agent_id") String agentId, @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(max = 64)
-        @Parameter(in = ParameterIn.PATH, description = "conversation_id", required = true, schema = @Schema())
-        @PathVariable("conversation_id") String conversationId,
-        @ApiParam(value = "RetrieveConversationQo: converted from multi query params") @Valid
-        RetrieveConversationQo retrieveConversationQo,
-        @RequestParam(value = "workspace_id", required = false) String workspaceId) {
 
-        return agentServiceProxyService.retrieveConversation(projectId, agentId, conversationId, retrieveConversationQo,
-            workspaceId).getBody();
-    }
-
-    @ApiOperation(value = "查看任务列表", nickname = "listTask", notes = "", response = TaskListRsp.class,
-        tags = {"TaskManagement"})
-    @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "", response = TaskListRsp.class),
-        @ApiResponse(code = 400, message = "", response = ErrorRsp.class)
-    })
-    @RequestMapping(value = "/v1/{project_id}/agent-manager/workflows/{workflow_id}/tasks",
-        produces = {"application/json"}, method = RequestMethod.GET)
-    public TaskListRsp listTask(@Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
-        @Parameter(in = ParameterIn.PATH, description = "租户项目id", required = true, schema = @Schema())
-        @PathVariable("project_id") String projectId, @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
-        @Parameter(in = ParameterIn.PATH, description = "工作流id", required = true, schema = @Schema())
-        @PathVariable("workflow_id") String workflowId,
-        @ApiParam(value = "ListTaskQo: converted from multi query params") @Valid  ListTaskQo listTaskQo,
-        @RequestParam(value = "workspace_id", required = false) String workspaceId) {
-
-        return agentServiceProxyService.listTask(projectId, workflowId, listTaskQo, workspaceId).getBody();
-    }
-
-    @ApiOperation(value = "获取异步任务详情", nickname = "retrieveTask", notes = "", response = TaskRsp.class,
-        tags = {"TaskManagement"})
-    @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "", response = TaskRsp.class),
-        @ApiResponse(code = 400, message = "", response = ErrorRsp.class)
-    })
-    @RequestMapping(value = "/v1/{project_id}/agent-manager/workflows/{workflow_id}/tasks/{task_id}",
-        produces = {"application/json"}, method = RequestMethod.GET)
-    public TaskRsp retrieveTask(@Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
-        @Parameter(in = ParameterIn.PATH, description = "租户项目id", required = true, schema = @Schema())
-        @PathVariable("project_id") String projectId, @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
-        @Parameter(in = ParameterIn.PATH, description = "工作流id", required = true, schema = @Schema())
-        @PathVariable("workflow_id") String workflowId, @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
-        @Parameter(in = ParameterIn.PATH, description = "异步任务id", required = true, schema = @Schema())
-        @PathVariable("task_id") String taskId,
-        @Pattern(regexp = "^[a-zA-Z0-9_()\\-]+$") @Size(min = 1, max = 64) @ApiParam(value = "项目空间id")
-        @RequestParam(value = "workspace_id", required = false) String workspaceId) {
-
-        return agentServiceProxyService.retrieveTask(projectId, workflowId, taskId, workspaceId).getBody();
-    }
-
-    @ApiOperation(value = "继续执行任务", nickname = "resumeTask", notes = "", response = TaskRsp.class,
-        tags = {"TaskManagement"})
-    @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "", response = TaskRsp.class),
-        @ApiResponse(code = 400, message = "", response = ErrorRsp.class)
-    })
-    @RequestMapping(value = "/v1/{project_id}/agent-manager/workflows/{workflow_id}/tasks/{task_id}",
-        produces = {"application/json"}, consumes = {"application/json"}, method = RequestMethod.POST)
-    public TaskRsp resumeTask(@Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
-        @Parameter(in = ParameterIn.PATH, description = "租户项目id", required = true, schema = @Schema())
-        @PathVariable("project_id") String projectId, @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
-        @Parameter(in = ParameterIn.PATH, description = "工作流id", required = true, schema = @Schema())
-        @PathVariable("workflow_id") String workflowId, @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
-        @Parameter(in = ParameterIn.PATH, description = "异步任务id", required = true, schema = @Schema())
-        @PathVariable("task_id") String taskId,
-        @Pattern(regexp = "^[a-zA-Z0-9_()\\-]+$") @Size(min = 1, max = 64) @ApiParam(value = "项目空间id")
-        @RequestParam(value = "workspace_id", required = false) String workspaceId,
-        @NotNull @ApiParam(value = "创建文件请求体", required = true) @Valid @RequestBody ResumeTaskReq body) {
-
-        return agentServiceProxyService.resumeTask(projectId, workflowId, taskId, workspaceId, body).getBody();
-    }
-
-    @ApiOperation(value = "修改任务信息", nickname = "modifyTask", notes = "", response = TaskRsp.class,
-        tags = {"TaskManagement"})
-    @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "", response = TaskRsp.class),
-        @ApiResponse(code = 400, message = "", response = ErrorRsp.class)
-    })
-    @RequestMapping(value = "/v1/{project_id}/agent-manager/workflows/{workflow_id}/tasks/{task_id}",
-        produces = {"application/json"}, consumes = {"application/json"}, method = RequestMethod.PUT)
-    public TaskRsp modifyTask(@Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
-        @Parameter(in = ParameterIn.PATH, description = "租户项目id", required = true, schema = @Schema())
-        @PathVariable("project_id") String projectId, @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
-        @Parameter(in = ParameterIn.PATH, description = "工作流id", required = true, schema = @Schema())
-        @PathVariable("workflow_id") String workflowId, @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
-        @Parameter(in = ParameterIn.PATH, description = "异步任务id", required = true, schema = @Schema())
-        @PathVariable("task_id") String taskId,
-        @Pattern(regexp = "^[a-zA-Z0-9_()\\-]+$") @Size(min = 1, max = 64) @ApiParam(value = "项目空间id")
-        @RequestParam(value = "workspace_id", required = false) String workspaceId,
-        @NotNull @ApiParam(value = "创建文件请求体", required = true) @Valid @RequestBody ModifyTaskReq body) {
-
-        return agentServiceProxyService.modifyTask(projectId, workflowId, taskId, workspaceId, body).getBody();
-    }
-
-    @ApiOperation(value = "取消异步任务详情", nickname = "deleteTask", notes = "", response = CommonDeleteRsp.class,
-        tags = {"TaskManagement"})
-    @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "", response = CommonDeleteRsp.class),
-        @ApiResponse(code = 400, message = "", response = ErrorRsp.class)
-    })
-    @RequestMapping(value = "/v1/{project_id}/agent-manager/workflows/{workflow_id}/tasks/{task_id}",
-        produces = {"application/json"}, method = RequestMethod.DELETE)
-    public CommonDeleteRsp deleteTask(@Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
-        @Parameter(in = ParameterIn.PATH, description = "租户项目id", required = true, schema = @Schema())
-        @PathVariable("project_id") String projectId, @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
-        @Parameter(in = ParameterIn.PATH, description = "工作流id", required = true, schema = @Schema())
-        @PathVariable("workflow_id") String workflowId, @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
-        @Parameter(in = ParameterIn.PATH, description = "异步任务id", required = true, schema = @Schema())
-        @PathVariable("task_id") String taskId,
-        @Pattern(regexp = "^[a-zA-Z0-9_()\\-]+$") @Size(min = 1, max = 64) @ApiParam(value = "项目空间id")
-        @RequestParam(value = "workspace_id", required = false) String workspaceId) {
-
-        return agentServiceProxyService.deleteTask(projectId, workflowId, taskId, workspaceId).getBody();
-    }
-
-    @ApiOperation(value = "取消异步任务详情", nickname = "cancelTask", notes = "", response = CancelTaskRsp.class,
-        tags = {"TaskManagement"})
-    @ApiResponses(value = {
-        @ApiResponse(code = 200, message = "", response = CancelTaskRsp.class),
-        @ApiResponse(code = 400, message = "", response = ErrorRsp.class)
-    })
-    @RequestMapping(value = "/v1/{project_id}/agent-manager/workflows/{workflow_id}/tasks/{task_id}/cancel",
-        produces = {"application/json"}, method = RequestMethod.DELETE)
-    public CancelTaskRsp cancelTask(@Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
-        @Parameter(in = ParameterIn.PATH, description = "租户项目id", required = true, schema = @Schema())
-        @PathVariable("project_id") String projectId, @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
-        @Parameter(in = ParameterIn.PATH, description = "工作流id", required = true, schema = @Schema())
-        @PathVariable("workflow_id") String workflowId, @Pattern(regexp = "^[a-zA-Z0-9_-]+$") @Size(min = 1, max = 64)
-        @Parameter(in = ParameterIn.PATH, description = "异步任务id", required = true, schema = @Schema())
-        @PathVariable("task_id") String taskId,
-        @Pattern(regexp = "^[a-zA-Z0-9_()\\-]+$") @Size(min = 1, max = 64) @ApiParam(value = "项目空间id")
-        @RequestParam(value = "workspace_id", required = false) String workspaceId) {
-
-        return agentServiceProxyService.cancelTask(projectId, workflowId, taskId, workspaceId).getBody();
-    }
 
     // 此接口已弃用
     @ApiOperation(value = "测试 mcp 服务", nickname = "testServer", notes = "测试 mcp 服务",

--- a/backend/studio-manager-service/src/main/java/com/openjiuwen/studio/agent/manager/entity/TaskEntity.java
+++ b/backend/studio-manager-service/src/main/java/com/openjiuwen/studio/agent/manager/entity/TaskEntity.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025-2025. All rights reserved.
+ */
+
+package com.openjiuwen.studio.agent.manager.entity;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.Date;
+
+/**
+ * 任务实体
+ */
+@Data
+@Builder
+public class TaskEntity {
+    private String id;
+    private String name;
+    @JsonProperty("conversation_id")
+    private String conversationId;
+    @JsonProperty("user_id")
+    private String userId;
+    @JsonProperty("domain_id")
+    private String domainId;
+    @JsonProperty("workspace_id")
+    private String workspaceId;
+    @JsonProperty("project_id")
+    private String projectId;
+    private String type;
+    private String mode;
+    @JsonProperty("app_id")
+    private String appId;
+    @JsonProperty("app_version")
+    private String appVersion;
+    @JsonProperty("is_published")
+    private Boolean isPublished;
+    private String status;
+    private String inputs;
+    private String outputs;
+    private Integer timeout;
+    private String message;
+    @JsonProperty("create_time")
+    private Date createTime;
+    @JsonProperty("start_time")
+    private Date startTime;
+    @JsonProperty("update_time")
+    private Date updateTime;
+    @JsonProperty("finish_time")
+    private Date finishTime;
+}

--- a/backend/studio-manager-service/src/main/java/com/openjiuwen/studio/agent/manager/mapper/AsyncTaskMapper.java
+++ b/backend/studio-manager-service/src/main/java/com/openjiuwen/studio/agent/manager/mapper/AsyncTaskMapper.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025-2025. All rights reserved.
+ */
+
+package com.openjiuwen.studio.agent.manager.mapper;
+
+import com.openjiuwen.studio.agent.manager.entity.TaskEntity;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.Date;
+import java.util.List;
+
+/**
+ * 任务数据库mapper
+ */
+@Mapper
+public interface AsyncTaskMapper {
+    int createEntity(@Param("entity") TaskEntity entity);
+
+    List<TaskEntity> getTaskEntity(@Param("entity") TaskEntity entity, @Param("sort") String sort,
+        @Param("order") String order);
+
+    int updateByPrimaryKey(@Param("entity") TaskEntity entity);
+
+    List<TaskEntity> getInitWorkflowTaskEntity(@Param("limit") int limit);
+
+    List<TaskEntity> getExpiredTaskEntity(@Param("expireTime") Date expireTime);
+
+    int deleteByIds(@Param("ids") List<String> ids);
+}

--- a/backend/studio-manager-service/src/main/java/com/openjiuwen/studio/agent/manager/model/Conversation.java
+++ b/backend/studio-manager-service/src/main/java/com/openjiuwen/studio/agent/manager/model/Conversation.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2024-2024. All rights reserved.
+ */
+
+package com.openjiuwen.studio.agent.manager.model;
+
+import com.openjiuwen.studio.agent.common.dto.agent.Message;
+
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Conversation model for Redis storage, matching runtime format.
+ */
+@Data
+public class Conversation {
+    private long lastUpdateTime = System.currentTimeMillis();
+    private List<Message> messageList = new ArrayList<>();
+    private boolean old;
+    private long dialogueCount = 1;
+
+    public void addDialogueCount() {
+        ++dialogueCount;
+    }
+}

--- a/backend/studio-manager-service/src/main/java/com/openjiuwen/studio/agent/manager/model/ExecuteParams.java
+++ b/backend/studio-manager-service/src/main/java/com/openjiuwen/studio/agent/manager/model/ExecuteParams.java
@@ -37,6 +37,8 @@ public class ExecuteParams {
 
     private String projectId;
 
+    private String workspaceId;
+
     /**
      * 工作流OBS IR路径
      */

--- a/backend/studio-manager-service/src/main/java/com/openjiuwen/studio/agent/manager/rce/client/AgentRuntimeClient.java
+++ b/backend/studio-manager-service/src/main/java/com/openjiuwen/studio/agent/manager/rce/client/AgentRuntimeClient.java
@@ -6,11 +6,7 @@ package com.openjiuwen.studio.agent.manager.rce.client;
 
 import com.alibaba.fastjson2.JSONObject;
 import com.openjiuwen.studio.agent.common.dto.BatchDeleteUserVariableMemoryResponseBody;
-import com.openjiuwen.studio.agent.common.dto.ExecutionQueries;
-import com.openjiuwen.studio.agent.common.dto.agent.ConversionQueries;
-import com.openjiuwen.studio.agent.common.dto.agent.ExecutionInfo;
 import com.openjiuwen.studio.agent.common.dto.agent.Feedback;
-import com.openjiuwen.studio.agent.common.dto.agent.Message;
 import com.openjiuwen.studio.agent.common.dto.agent.Status;
 import com.openjiuwen.studio.agent.common.dto.analytics.AnalyticsEventReq;
 import com.openjiuwen.studio.agent.common.dto.analytics.AnalyticsEventResp;
@@ -21,40 +17,11 @@ import com.openjiuwen.studio.agent.common.dto.mcp.McpValidationResp;
 import com.openjiuwen.studio.agent.common.dto.md.ChatCompletionRequest;
 import com.openjiuwen.studio.agent.common.dto.md.ModelServiceCheckReq;
 import com.openjiuwen.studio.agent.common.dto.md.ModelServiceCheckRsp;
-import com.openjiuwen.studio.agent.common.dto.run.AdditionalQuestionsReq;
-import com.openjiuwen.studio.agent.common.dto.run.AdditionalQuestionsWorkflowReq;
-import com.openjiuwen.studio.agent.common.dto.run.AsrReq;
-import com.openjiuwen.studio.agent.common.dto.run.AsrRsp;
-import com.openjiuwen.studio.agent.common.dto.run.CancelTaskRsp;
-import com.openjiuwen.studio.agent.common.dto.run.ConversationDeleteResp;
-import com.openjiuwen.studio.agent.common.dto.run.CreateTaskReq;
-import com.openjiuwen.studio.agent.common.dto.run.GetControllerExecutionDetailQo;
-import com.openjiuwen.studio.agent.common.dto.run.GetExecutionInsightQo;
-import com.openjiuwen.studio.agent.common.dto.run.ListControllerExecutionsQo;
-import com.openjiuwen.studio.agent.common.dto.run.ListConversationQueriesQo;
-import com.openjiuwen.studio.agent.common.dto.run.ListExecutionQueriesQo;
-import com.openjiuwen.studio.agent.common.dto.run.ListTaskQo;
-import com.openjiuwen.studio.agent.common.dto.run.ModifyTaskReq;
-import com.openjiuwen.studio.agent.common.dto.run.ResetUserVariableMemoryResponseBody;
-import com.openjiuwen.studio.agent.common.dto.run.ResumeTaskReq;
-import com.openjiuwen.studio.agent.common.dto.run.RetrieveConversationMemoryQo;
-import com.openjiuwen.studio.agent.common.dto.run.RetrieveConversationQo;
-import com.openjiuwen.studio.agent.common.dto.run.RetrieveTaskQo;
-import com.openjiuwen.studio.agent.common.dto.run.RunToolRequestBody;
-import com.openjiuwen.studio.agent.common.dto.run.TaskListRsp;
-import com.openjiuwen.studio.agent.common.dto.run.TaskRsp;
+import com.openjiuwen.studio.agent.common.dto.run.*;
 import com.openjiuwen.studio.agent.common.dto.tool.RunToolResponseBody;
 import com.openjiuwen.studio.agent.common.entity.Text2AudioReq;
 import com.openjiuwen.studio.agent.manager.constant.CommonConstant;
-import com.openjiuwen.studio.agent.manager.dto.AgentRunReq;
-import com.openjiuwen.studio.agent.manager.dto.AutoAddResultJsonObject;
-import com.openjiuwen.studio.agent.manager.dto.BatchDeleteUserVariableMemoryRequestBody;
-import com.openjiuwen.studio.agent.manager.dto.CommonDeleteRsp;
-import com.openjiuwen.studio.agent.manager.dto.McpServerReq;
-import com.openjiuwen.studio.agent.manager.dto.McpServerTools;
-import com.openjiuwen.studio.agent.manager.dto.MemoryVariable;
-import com.openjiuwen.studio.agent.manager.dto.ReleaseInfo;
-import com.openjiuwen.studio.agent.manager.dto.WorkflowRunReq;
+import com.openjiuwen.studio.agent.manager.dto.*;
 import com.openjiuwen.studio.agent.manager.dto.runtime.Audio2TextReq;
 import com.openjiuwen.studio.agent.manager.dto.runtime.EmbeddingRequest;
 import com.openjiuwen.studio.agent.manager.dto.runtime.RankDocumentsRequest;
@@ -62,26 +29,16 @@ import com.openjiuwen.studio.agent.manager.dto.runtime.StsTextResp;
 import com.openjiuwen.studio.agent.manager.rce.models.AskModelReq;
 import com.openjiuwen.studio.agent.manager.rce.models.McpCallToolRequest;
 import com.openjiuwen.studio.prompt.engineering.dto.IndustryVo;
-
 import io.swagger.annotations.ApiParam;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import reactor.core.publisher.Flux;
-
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.cloud.openfeign.SpringQueryMap;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import reactor.core.publisher.Flux;
 
 import java.util.List;
 
@@ -321,73 +278,12 @@ public interface AgentRuntimeClient {
         @PathVariable("project_id") String projectId, @PathVariable("agent_id") String agentId,
         @RequestParam("workspace_id") String workspaceId);
 
-    @GetMapping(value = "/v1/{project_id}/agents/{agent_id}/conversations/{conversation_id}/history")
-    ResponseEntity<List<Message>> retrieveConversation(
-        @RequestHeader(CommonConstant.X_AUTH_TOKEN) String authToken,
-        @PathVariable("project_id") String projectId, @PathVariable("agent_id") String agentId,
-        @PathVariable("conversation_id") String conversationId,
-        @SpringQueryMap RetrieveConversationQo retrieveConversationQo,
-        @RequestParam("workspace_id") String workspaceId);
-
-    @DeleteMapping(value = "/v1/{project_id}/agents/{agent_id}/conversations/{conversation_id}/history")
-    ResponseEntity<ConversationDeleteResp> deleteConversation(
-        @RequestHeader(CommonConstant.X_AUTH_TOKEN) String authToken,
-        @PathVariable("project_id") String projectId, @PathVariable("agent_id") String agentId,
-        @PathVariable("conversation_id") String conversationId, @RequestParam("version_id") String versionId,
-        @RequestParam("workspace_id") String workspaceId);
-
     @PostMapping(value = "/v1/{project_id}/workflows/{workflow_id}/tasks")
     ResponseEntity<TaskRsp> createTask(
         @RequestHeader(CommonConstant.X_AUTH_TOKEN) String authToken,
         @PathVariable("project_id") String projectId,
         @PathVariable("workflow_id") String workflowId, @RequestParam(value = "version", required = false) String version,
         @RequestParam(value = "workspace_id", required = false) String workspaceId, @RequestBody @NotNull @Valid CreateTaskReq body);
-
-    @GetMapping("/v1/{project_id}/workflows/{workflow_id}/tasks")
-    ResponseEntity<TaskListRsp> listTask(
-        @RequestHeader(CommonConstant.X_AUTH_TOKEN) String authToken,
-        @PathVariable("project_id") String projectId,
-        @PathVariable("workflow_id") String workflowId,
-        @RequestParam(value = "status", required = false) String status,
-        @RequestParam(value = "type", required = false) String type,
-        @RequestParam(value = "sort", required = false) String sort,
-        @RequestParam(value = "order", required = false) String order,
-        @RequestParam(value = "workspace_id", required = false) String workspaceId);
-
-    @GetMapping("/v1/{project_id}/workflows/{workflow_id}/tasks/{task_id}")
-    ResponseEntity<TaskRsp> retrieveTask(
-        @RequestHeader(CommonConstant.X_AUTH_TOKEN) String authToken,
-        @PathVariable("project_id") String projectId,
-        @PathVariable("workflow_id") String workflowId, @PathVariable("task_id") String taskId,
-        @RequestParam(value = "workspace_id", required = false) String workspaceId);
-
-    @PostMapping("/v1/{project_id}/workflows/{workflow_id}/tasks/{task_id}")
-    ResponseEntity<TaskRsp> resumeTask(
-        @RequestHeader(CommonConstant.X_AUTH_TOKEN) String authToken,
-        @PathVariable("project_id") String projectId,
-        @PathVariable("workflow_id") String workflowId, @PathVariable("task_id") String taskId,
-        @RequestParam(value = "workspace_id", required = false) String workspaceId, @RequestBody @Valid @NotNull ResumeTaskReq bpdy);
-
-    @PutMapping("/v1/{project_id}/workflows/{workflow_id}/tasks/{task_id}")
-    ResponseEntity<TaskRsp> modifyTask(
-        @RequestHeader(CommonConstant.X_AUTH_TOKEN) String authToken,
-        @PathVariable("project_id") String projectId,
-        @PathVariable("workflow_id") String workflowId, @PathVariable("task_id") String taskId,
-        @RequestParam(value = "workspace_id", required = false) String workspaceId, @RequestBody @NotNull @Valid ModifyTaskReq body);
-
-    @DeleteMapping("/v1/{project_id}/workflows/{workflow_id}/tasks/{task_id}")
-    ResponseEntity<CommonDeleteRsp> deleteTask(
-        @RequestHeader(CommonConstant.X_AUTH_TOKEN) String authToken,
-        @PathVariable("project_id") String projectId,
-        @PathVariable("workflow_id") String workflowId, @PathVariable("task_id") String taskId,
-        @RequestParam(value = "workspace_id", required = false) String workspaceId);
-
-    @DeleteMapping("/v1/{project_id}/workflows/{workflow_id}/tasks/{task_id}/cancel")
-    ResponseEntity<CancelTaskRsp> cancelTask(
-        @RequestHeader(CommonConstant.X_AUTH_TOKEN) String authToken,
-        @PathVariable("project_id") String projectId,
-        @PathVariable("workflow_id") String workflowId, @PathVariable("task_id") String taskId,
-        @RequestParam(value = "workspace_id", required = false) String workspaceId);
 
     @PostMapping("/v1/{project_id}/mcp-servers/test")
     ResponseEntity<McpValidationResp> testServer(

--- a/backend/studio-manager-service/src/main/java/com/openjiuwen/studio/agent/manager/service/ConversationHistoryService.java
+++ b/backend/studio-manager-service/src/main/java/com/openjiuwen/studio/agent/manager/service/ConversationHistoryService.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026-2026. All rights reserved.
+ */
+
+package com.openjiuwen.studio.agent.manager.service;
+
+import com.alibaba.fastjson2.JSON;
+import com.alibaba.fastjson2.TypeReference;
+import com.openjiuwen.studio.agent.common.dto.agent.ConversationInfo;
+import com.openjiuwen.studio.agent.common.dto.agent.Message;
+import com.openjiuwen.studio.agent.common.dto.run.ConversationDeleteResp;
+import com.openjiuwen.studio.agent.common.dto.run.RetrieveConversationQo;
+import com.openjiuwen.studio.agent.common.enums.StudioError;
+import com.openjiuwen.studio.agent.common.exception.AgentStudioException;
+import com.openjiuwen.studio.agent.common.redis.RedisClient;
+import com.openjiuwen.studio.agent.common.redis.RedisLock;
+import com.openjiuwen.studio.agent.common.utils.RequestContextUtils;
+import com.openjiuwen.studio.agent.manager.constant.Constant;
+import com.openjiuwen.studio.agent.manager.dto.ConversationParams;
+import com.openjiuwen.studio.agent.manager.model.Conversation;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 会话历史服务，直接操作Redis，从 runtime 迁移而来
+ */
+@Slf4j
+@Service
+public class ConversationHistoryService implements IConversationHistoryService {
+
+    private static final String LOCK_STR = ":lock";
+
+    @Autowired
+    private RedisClient redisClient;
+
+    @Value("${redis.max_message_num}")
+    private int maxMessageNum;
+
+    @Value("${redis.max_message_size:5000000}")
+    private long maxMessageSize;
+
+    @Value("${redis.expire_time}")
+    private long expireTime;
+
+    @Value("${agent.insight-conv-rel:}")
+    private String agentInsightConvRel;
+
+    @Override
+    public ConversationDeleteResp deleteConversationHistory(String projectId, String agentId,
+            String conversationId, String versionId, String workspaceId) {
+        RedisLock lock = null;
+        try {
+            String conversationKey = getConversationKey(agentId, conversationId, versionId);
+            redisClient.delete(conversationKey);
+
+            // 删除conversation列表中的记录
+            if (StringUtils.isNotEmpty(agentInsightConvRel)) {
+                String conversationsKey = String.format(agentInsightConvRel, agentId, RequestContextUtils.getRequestUserId());
+                lock = redisClient.getLock(conversationsKey + LOCK_STR);
+                if (lock.tryLock(Duration.ofSeconds(3))) {
+                    List<ConversationInfo> conversationInfoList = new ArrayList<>();
+                    if (redisClient.exists(conversationsKey)) {
+                        String text = redisClient.get(conversationsKey);
+                        if (StringUtils.isNotEmpty(text)) {
+                            conversationInfoList = JSON.parseObject(text, new TypeReference<List<ConversationInfo>>() {});
+                        }
+                    }
+                    conversationInfoList.removeIf(
+                        conversationInfo -> conversationInfo.getConversationId().equals(conversationId));
+                    redisClient.set(conversationsKey, JSON.toJSONString(conversationInfoList),
+                        Duration.ofSeconds(expireTime));
+                } else {
+                    log.error("failed to get lock, other user is processing same workflow!");
+                    throw new AgentStudioException(StudioError.REDISSON_GET_BUCKET_FAILED);
+                }
+            }
+            return new ConversationDeleteResp().setId(conversationId);
+        } catch (AgentStudioException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("delete conversation failed", e);
+            throw new AgentStudioException(StudioError.REDISSON_GET_BUCKET_FAILED);
+        } finally {
+            if (lock != null) {
+                lock.unlock();
+            }
+        }
+    }
+
+    @Override
+    public List<Message> retrieveConversationHistory(String projectId, String agentId,
+            String conversationId, RetrieveConversationQo retrieveConversationQo, String workspaceId) {
+        try {
+            String versionId = retrieveConversationQo != null ? retrieveConversationQo.getVersionId() : null;
+            String conversationKey = getConversationKey(agentId, conversationId, versionId);
+            if (!redisClient.exists(conversationKey)) {
+                return new ArrayList<>();
+            }
+            String conversationStr = redisClient.get(conversationKey);
+            if (StringUtils.isEmpty(conversationStr)) {
+                return new ArrayList<>();
+            }
+            Conversation conversation = JSON.parseObject(conversationStr, Conversation.class);
+            List<Message> messageList = conversation.getMessageList()
+                .stream()
+                .sorted(Comparator.comparing(Message::getCreateTime, Comparator.nullsFirst(Comparator.naturalOrder())))
+                .toList();
+            redisClient.expire(conversationKey, Duration.ofSeconds(expireTime));
+            log.info("retrieve: projectId={}, conversationId={}, messagesSize={} ", projectId, conversationId,
+                messageList.size());
+            return messageList;
+        } catch (Exception e) {
+            log.error("retrieve conversation failed", e);
+            throw new AgentStudioException(StudioError.REDISSON_GET_BUCKET_FAILED);
+        }
+    }
+
+    private String getConversationKey(String agentId, String conversationId, String versionId) {
+        String key = String.format("%s_%s_%s", conversationId, agentId, RequestContextUtils.getRequestUserId());
+        if (StringUtils.isEmpty(versionId)) {
+            return key;
+        }
+        return key + "_" + versionId;
+    }
+
+    /**
+     * 根据projectId，conversationId更新会话信息
+     *
+     * @param conversationParams 会话参数
+     * @param messages message list
+     * @return MessageList
+     */
+    public List<Message> updateConversation(ConversationParams conversationParams, List<Message> messages, boolean dialogueEnd) {
+        Long startTime = System.currentTimeMillis();
+        try {
+            Conversation conversation;
+            List<Message> messageList;
+            String conversationKey = getConversationKey(conversationParams.getId(),
+                    conversationParams.getConversationId(), conversationParams.getVersionId());
+            String conversationStr = redisClient.get(conversationKey);
+            if (StringUtils.isEmpty(conversationStr) || Constant.AppType.CONTROLLER.equals(
+                    conversationParams.getExecuteType())) {
+                // agent接口刷新conversation insight信息，工作流单独刷新逻辑和executions保持一致
+                messageList = new ArrayList<>();
+                conversation = new Conversation();
+                conversation.setMessageList(messageList);
+            } else {
+                conversation = JSON.parseObject(conversationStr, Conversation.class);
+                messageList = conversation.getMessageList();
+            }
+            messageList.addAll(messages);
+            if (messageList.size() >= maxMessageNum) {
+                messageList = new ArrayList<>(
+                        messageList.subList(messageList.size() - maxMessageNum, messageList.size()));
+            }
+            long size = 0L;
+            int offset = 0;
+
+            for (int i = messageList.size() - 1; i >= 0; i--) {
+                Object msg = messageList.get(i);
+                if (msg instanceof Message mm) {
+                    size += mm.getContent().length();
+                } else if (msg instanceof Map) {
+                    Map<String, Object> map = (Map<String, Object>) msg;
+                    String content = map.getOrDefault("content", "").toString();
+                    size += content.length();
+                }
+
+                if (size > maxMessageSize) {
+                    log.warn("Conversation message size exceed limit. size:{} limit:{}", size, maxMessageSize);
+                    break;
+                }
+                ++offset;
+            }
+            messageList = getTrimmedMessageList(messageList, offset);
+
+            // 设置会话最后更新时间
+            conversation.setMessageList(messageList);
+            conversation.setLastUpdateTime(System.currentTimeMillis());
+            if (dialogueEnd) {
+                conversation.addDialogueCount();
+            }
+            redisClient.set(conversationKey, JSON.toJSONString(conversation), Duration.ofSeconds(expireTime));
+            log.info("update: projectId={}, conversationId={}, messagesSize={} ", conversationParams.getProjectId(),
+                    conversationParams.getConversationId(), messageList.size());
+            return messageList;
+        } catch (Exception e) {
+            log.error("redisson get bucket failed", e);
+            throw new AgentStudioException(StudioError.REDISSON_GET_BUCKET_FAILED);
+        } finally {
+            Long endTime = System.currentTimeMillis();
+            log.info("update conversation cost {}ms, conversation id: {}", endTime - startTime,
+                    conversationParams.getConversationId());
+        }
+    }
+
+    private List<Message> getTrimmedMessageList(List<Message> messageList, int offset) {
+        if (messageList.isEmpty()) {
+            return messageList;
+        }
+        if (offset > 0) {
+            return messageList.subList(messageList.size() - offset, messageList.size());
+        }
+        return messageList.subList(messageList.size() - 1, messageList.size());
+    }
+}

--- a/backend/studio-manager-service/src/main/java/com/openjiuwen/studio/agent/manager/service/TaskManagementService.java
+++ b/backend/studio-manager-service/src/main/java/com/openjiuwen/studio/agent/manager/service/TaskManagementService.java
@@ -1,0 +1,329 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025-2025. All rights reserved.
+ */
+
+package com.openjiuwen.studio.agent.manager.service;
+
+import com.alibaba.fastjson2.JSONObject;
+import com.github.pagehelper.PageInfo;
+import com.openjiuwen.studio.agent.common.dto.agent.Message;
+import com.openjiuwen.studio.agent.common.dto.run.*;
+import com.openjiuwen.studio.agent.common.enums.StudioError;
+import com.openjiuwen.studio.agent.common.exception.AgentStudioException;
+import com.openjiuwen.studio.agent.common.redis.RedisClient;
+import com.openjiuwen.studio.agent.common.utils.RequestContextUtils;
+import com.openjiuwen.studio.agent.manager.constant.Constant;
+import com.openjiuwen.studio.agent.manager.dto.CommonDeleteRsp;
+import com.openjiuwen.studio.agent.manager.dto.ConversationParams;
+import com.openjiuwen.studio.agent.manager.entity.TaskEntity;
+import com.openjiuwen.studio.agent.manager.enums.MessageRole;
+import com.openjiuwen.studio.agent.manager.mapper.AsyncTaskMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Strings;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * 任务管理面service
+ *
+ */
+@Slf4j
+@Service
+public class TaskManagementService implements ITaskManagementService {
+    /**
+     * redis存header key
+     */
+    private static final String REDIS_HEADER_KEY = "agent:runtime:async:header:%s";
+
+    @Autowired
+    AsyncTaskMapper asyncTaskMapper;
+
+    @Autowired
+    RedisClient redisClient;
+
+    @Autowired
+    TaskRuntimeService taskRuntimeService;
+
+    @Autowired
+    ConversationHistoryService conversationHistoryService;
+
+    /**
+     * 异步任务超期时间，建议调试记录超期时间保持一致
+     */
+    @Value("${task.async.expire-days:}")
+    private int taskAsyncExpireDays;
+
+    /**
+     * 异步任务最长执行时间
+     */
+    @Value("${task.async.max-execute-milliseconds:}")
+    private int taskAsyncMaxExecuteMilliseconds;
+
+    @Override
+    public CancelTaskRsp cancelTask(String projectId, String workflowId, String taskId, String workspaceId) {
+        TaskEntity taskEntity = getTaskEntityById(projectId, workflowId, taskId, workspaceId);
+
+        CancelTaskRsp cancelTaskRsp = new CancelTaskRsp().setId(taskId).setWorkflowId(workflowId);
+        if (StringUtils.isEmpty(taskEntity.getId())) {
+            return cancelTaskRsp.setStatus(TaskStatus.FAILED).setMessage("Please check your permission!");
+        }
+        // 取消初始化和允许中任务，同时释放线程池和连接池
+        if (Strings.CS.equals(taskEntity.getStatus(), TaskStatus.INIT.getValue()) || Strings.CS.equals(
+                taskEntity.getStatus(), TaskStatus.RUNNING.getValue())) {
+            taskEntity.setStatus(TaskStatus.CANCELLED.getValue());
+            taskEntity.setMessage("Task has been cancelled successfully!");
+            Date currentDate = new Date(System.currentTimeMillis());
+            taskEntity.setUpdateTime(currentDate);
+            taskEntity.setFinishTime(currentDate);
+            asyncTaskMapper.updateByPrimaryKey(taskEntity);
+            taskRuntimeService.cancelTask(taskId);
+            setUserQueryToHistory(workflowId, taskEntity.getConversationId(), currentDate, "会话取消",
+                    MessageRole.ASSISTANT.name().toLowerCase(Locale.ROOT));
+            return cancelTaskRsp.setStatus(TaskStatus.valueOf(taskEntity.getStatus()))
+                    .setMessage(taskEntity.getMessage());
+        } else {
+            return cancelTaskRsp.setStatus(TaskStatus.valueOf(taskEntity.getStatus()))
+                    .setMessage("Task status is not init or running!");
+        }
+    }
+
+    @Override
+    public TaskRsp createTask(String projectId, String workflowId, String version, String workspaceId,
+                              CreateTaskReq body) {
+        // 生成任务ID和conversation ID
+        String taskId = UUID.randomUUID().toString();
+        String conversationId = UUID.randomUUID().toString();
+        Date currentTime = new Date(System.currentTimeMillis());
+
+        // 任务header存入redis
+        redisClient.set(String.format(REDIS_HEADER_KEY, taskId), JSONObject.toJSONString(getNonSensitiveHeader()),
+                Duration.ofDays(taskAsyncExpireDays));
+
+        if (body.getInputs() != null) {
+            setUserQueryToHistory(workflowId, conversationId, currentTime, JSONObject.toJSONString(body.getInputs()),
+                    MessageRole.USER.name().toLowerCase(Locale.ROOT));
+        }
+
+        // 如已发布工作流，appVersion为版本时间，如未发布工作流，appVersion为工作流最后编辑时间
+        String appVersion = determineAppVersion(version, body);
+
+        // 创建任务实体
+        TaskEntity taskEntity = TaskEntity.builder()
+                .id(taskId)
+                .name(body.getName())
+                .conversationId(conversationId)
+                .userId(RequestContextUtils.getRequestUserId())
+                .projectId(projectId)
+                .domainId(RequestContextUtils.getRequestUserDomainId())
+                .workspaceId(workspaceId)
+                .type(body.getType())
+                .mode(body.getMode())
+                .appId(workflowId)
+                .appVersion(appVersion)
+                .isPublished(StringUtils.isNotEmpty(version))
+                .status(body.getInputs() != null ? TaskStatus.INIT.getValue() : TaskStatus.PENDING.getValue())
+                .inputs(body.getInputs() != null ? JSONObject.toJSONString(body.getInputs()) : null)
+                .timeout(getLimitedTimeOut(body.getTimeout()))
+                .createTime(currentTime)
+                .updateTime(currentTime)
+                .build();
+        asyncTaskMapper.createEntity(taskEntity);
+        return convertEntityToRsp(taskEntity);
+    }
+
+    private Map<String, String> getNonSensitiveHeader() {
+        Map<String, String> headers = new HashMap<>();
+        ServletRequestAttributes servletRequestAttributes
+                = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if (servletRequestAttributes != null) {
+            HttpServletRequest request = servletRequestAttributes.getRequest();
+            Enumeration<String> headerNames = request.getHeaderNames();
+
+            // 遍历并过滤非敏感header存redis
+            while (headerNames.hasMoreElements()) {
+                String headerName = headerNames.nextElement();
+                String headerValue = request.getHeader(headerName);
+                // Include all headers for async task execution
+                headers.put(headerName, headerValue);
+            }
+        }
+        return headers;
+    }
+
+    @Override
+    public CommonDeleteRsp deleteTask(String projectId, String workflowId, String taskId, String workspaceId) {
+        TaskEntity taskEntity = getTaskEntityById(projectId, workflowId, taskId, workspaceId);
+        CommonDeleteRsp commonDeleteRsp = new CommonDeleteRsp().setId(taskId);
+        if (!StringUtils.isEmpty(taskEntity.getId())) {
+            asyncTaskMapper.deleteByIds(Collections.singletonList(taskId));
+        }
+        return commonDeleteRsp;
+    }
+
+    @Override
+    public TaskListRsp listTask(String projectId, String workflowId, ListTaskQo listTaskQo) {
+        TaskEntity filter = TaskEntity.builder()
+                .projectId(projectId)
+                .type(listTaskQo.getType())
+                .status(listTaskQo.getStatus())
+                .workspaceId(listTaskQo.getWorkspaceId())
+                .appId(workflowId)
+                .build();
+        List<TaskEntity> taskEntities = asyncTaskMapper.getTaskEntity(filter, listTaskQo.getSort(),
+                listTaskQo.getOrder());
+        PageInfo<TaskEntity> pageInfo = new PageInfo<>(taskEntities);
+
+        List<TaskListItem> infos = new ArrayList<>();
+        for (TaskEntity taskEntity : taskEntities) {
+            infos.add(convertEntityToTaskItem(taskEntity));
+        }
+        return new TaskListRsp().setData(infos).setCount(pageInfo.getTotal()).setWorkflowId(workflowId);
+    }
+
+    @Override
+    public TaskRsp resumeTask(String projectId, String workflowId, String taskId, String workspaceId,
+                              ResumeTaskReq body) {
+        // 任务header存入redis
+        redisClient.set(String.format(REDIS_HEADER_KEY, taskId), JSONObject.toJSONString(getNonSensitiveHeader()),
+                Duration.ofDays(taskAsyncExpireDays));
+
+        TaskEntity taskEntity = getTaskEntityById(projectId, workflowId, taskId, workspaceId);
+        if (StringUtils.isEmpty(taskEntity.getId())) {
+            throw new AgentStudioException(StudioError.WORKFLOW_ASYNC_TASK_NOT_FOUND);
+        }
+        checkStatus(TaskStatus.valueOf(taskEntity.getStatus()), taskEntity.getType());
+        Date currentTime = new Date(System.currentTimeMillis());
+        taskEntity.setStatus(TaskStatus.INIT.getValue());
+        taskEntity.setUpdateTime(currentTime);
+        taskEntity.setInputs(JSONObject.toJSONString(body.getInputs()));
+        taskEntity.setTimeout(getLimitedTimeOut(body.getTimeout()));
+        asyncTaskMapper.updateByPrimaryKey(taskEntity);
+        if (body.getInputs() != null) {
+            setUserQueryToHistory(workflowId, taskEntity.getConversationId(), currentTime,
+                    JSONObject.toJSONString(body.getInputs()), MessageRole.USER.name().toLowerCase(Locale.ROOT));
+        }
+        return convertEntityToRsp(taskEntity);
+    }
+
+    @Override
+    public TaskRsp modifyTask(String projectId, String workflowId, String taskId, String workspaceId,
+                              ModifyTaskReq body) {
+        // 修改接口当前支持修改name和超时时间
+        TaskEntity entity = TaskEntity.builder()
+                .id(taskId)
+                .projectId(projectId)
+                .userId(RequestContextUtils.getRequestUserId())
+                .workspaceId(workspaceId)
+                .appId(workflowId)
+                .name(body.getName())
+                .timeout(getLimitedTimeOut(body.getTimeout()))
+                .updateTime(new Date(System.currentTimeMillis()))
+                .build();
+        asyncTaskMapper.updateByPrimaryKey(entity);
+        return retrieveTask(projectId, workflowId, taskId, new RetrieveTaskQo().setWorkspaceId(workspaceId));
+    }
+
+    @Override
+    public TaskRsp retrieveTask(String projectId, String workflowId, String taskId, RetrieveTaskQo retrieveTaskQo) {
+        TaskEntity taskEntity = getTaskEntityById(projectId, workflowId, taskId, retrieveTaskQo.getWorkspaceId());
+        return convertEntityToRsp(taskEntity);
+    }
+
+    private TaskEntity getTaskEntityById(String projectId, String workflowId, String taskId, String workspaceId) {
+        TaskEntity filter = TaskEntity.builder()
+                .id(taskId)
+                .projectId(projectId)
+                .appId(workflowId)
+                .workspaceId(workspaceId)
+                .build();
+        List<TaskEntity> taskEntities = asyncTaskMapper.getTaskEntity(filter, null, null);
+        if (taskEntities.isEmpty()) {
+            return TaskEntity.builder().build();
+        }
+        return taskEntities.get(0);
+    }
+
+    private TaskListItem convertEntityToTaskItem(TaskEntity taskEntity) {
+        return new TaskListItem().setId(taskEntity.getId())
+                .setName(taskEntity.getName())
+                .setType(taskEntity.getType())
+                .setIsPublished(taskEntity.getIsPublished())
+                .setStatus(TaskStatus.valueOf(taskEntity.getStatus()))
+                .setCreateTime(taskEntity.getCreateTime())
+                .setFinishTime(taskEntity.getFinishTime());
+    }
+
+    private TaskRsp convertEntityToRsp(TaskEntity taskEntity) {
+        return new TaskRsp().setId(taskEntity.getId())
+                .setName(taskEntity.getName())
+                .setConversationId(taskEntity.getConversationId())
+                .setIsPublished(taskEntity.getIsPublished())
+                .setInputs(JSONObject.parseObject(taskEntity.getInputs()))
+                .setOutputs(JSONObject.parseObject(taskEntity.getOutputs()))
+                .setStatus(TaskStatus.valueOf(taskEntity.getStatus()))
+                .setMessage(StringUtils.isEmpty(taskEntity.getMessage()) ? null : taskEntity.getMessage())
+                .setCreateTime(taskEntity.getCreateTime())
+                .setUpdateTime(taskEntity.getUpdateTime())
+                .setFinishTime(taskEntity.getFinishTime())
+                .setWorkflow(new TaskRspWorkflow().setId(taskEntity.getAppId())
+                        .setType(taskEntity.getType())
+                        .setVersionId(taskEntity.getAppVersion()));
+    }
+
+    private Integer getLimitedTimeOut(Integer timeout) {
+        return timeout != null ? Math.max(Math.min(taskAsyncMaxExecuteMilliseconds, timeout), 1) : null;
+    }
+
+    public void checkStatus(TaskStatus currentStatus, String workflowType) {
+        switch (currentStatus) {
+            case INIT, RUNNING:
+                throw new AgentStudioException(StudioError.WORKFLOW_ASYNC_NOT_PENDING);
+            case COMPLETED, FAILED:
+                if (!"chat".equalsIgnoreCase(workflowType)) {
+                    throw new AgentStudioException(StudioError.WORKFLOW_ASYNC_NOT_PENDING);
+                }
+                break;
+            default:
+                break;
+        }
+    }
+
+    public void setUserQueryToHistory(String workflowId, String conversationId, Date currentTime, String content,
+                                      String name) {
+        ConversationParams conversationParams = new ConversationParams()
+                .setExecuteType(Constant.AppType.WORKFLOW)
+                .setId(workflowId)
+                .setConversationId(conversationId);
+        Message message = new Message();
+        message.setContent(content);
+        message.setRole(name);
+        message.setCreateTime(currentTime.getTime());
+        conversationHistoryService.updateConversation(conversationParams, List.of(message), false);
+    }
+
+    private String determineAppVersion(String version, CreateTaskReq body) {
+        if (StringUtils.isNotEmpty(version)) {
+            return version;
+        }
+        if (body.getVersion() != null) {
+            return body.getVersion().toString();
+        }
+        return null;
+    }
+}

--- a/backend/studio-manager-service/src/main/java/com/openjiuwen/studio/agent/manager/service/TaskRuntimeService.java
+++ b/backend/studio-manager-service/src/main/java/com/openjiuwen/studio/agent/manager/service/TaskRuntimeService.java
@@ -1,0 +1,662 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2025-2025. All rights reserved.
+ */
+
+package com.openjiuwen.studio.agent.manager.service;
+
+import com.alibaba.fastjson2.JSON;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.alibaba.fastjson2.JSONObject;
+import com.openjiuwen.studio.agent.common.dto.agent.Message;
+import com.openjiuwen.studio.agent.common.dto.agent.Status;
+import com.openjiuwen.studio.agent.common.dto.run.TaskStatus;
+import com.openjiuwen.studio.agent.common.enums.StudioError;
+import com.openjiuwen.studio.agent.common.exception.AgentStudioException;
+import com.openjiuwen.studio.agent.common.redis.RedisClient;
+import com.openjiuwen.studio.agent.common.redis.RedisLock;
+import com.openjiuwen.studio.agent.common.utils.I18nUtil;
+import com.openjiuwen.studio.agent.common.utils.RequestContextUtils;
+import com.openjiuwen.studio.agent.common.utils.StrUtils;
+import com.openjiuwen.studio.agent.manager.constant.Constant;
+import com.openjiuwen.studio.agent.manager.dto.ConversationParams;
+import com.openjiuwen.studio.agent.manager.dto.WorkflowRunReq;
+import com.openjiuwen.studio.agent.manager.dto.WorkflowRunRsp;
+import com.openjiuwen.studio.agent.manager.entity.TaskEntity;
+import com.openjiuwen.studio.agent.manager.entity.insight.WorkflowInstanceEntity;
+import com.openjiuwen.studio.agent.manager.entity.insight.WorkflowRunResult;
+import com.openjiuwen.studio.agent.manager.enums.MessageRole;
+import com.openjiuwen.studio.agent.manager.enums.WorkflowRunStatus;
+import com.openjiuwen.studio.agent.manager.model.AsyncTaskParamHolder;
+import com.openjiuwen.studio.agent.manager.model.Conversation;
+import com.openjiuwen.studio.agent.manager.mapper.AsyncTaskMapper;
+import com.openjiuwen.studio.agent.manager.model.ExecuteParams;
+import com.openjiuwen.studio.agent.manager.rce.client.AgentRuntimeClient;
+import com.openjiuwen.studio.agent.manager.service.proxy.AgentServiceProxyService;
+import com.openjiuwen.studio.agent.manager.service.proxy.AsyncWorkflowListener;
+
+import com.openjiuwen.studio.agent.manager.utils.JsonUtils;
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+import javax.annotation.PostConstruct;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * 任务运行时Service
+ */
+@Slf4j
+@Service
+public class TaskRuntimeService {
+    /**
+     * redis存header key
+     */
+    private static final String REDIS_HEADER_KEY = "agent:runtime:async:header:%s";
+
+    /**
+     * redis存header key
+     */
+    private static final String KEEP_ALIVE = "Keep-Alive";
+
+    /**
+     * redis存header key
+     */
+    private static final String TIMEOUT_VALUE = "timeout=%s";
+
+    /**
+     * 默认超时时间，单位毫秒
+     */
+    private static final int DEFAULT_TIMEOUT_MILLISECONDS = 3600000;
+
+    /**
+     * 分布式锁等待时间
+     */
+    private static final int LOCK_TIME = 10;
+
+    /**
+     * 最大错误描述长度
+     */
+    private static final int MAX_ERROR_MESSAGE_SIZE = 2048;
+
+    /**
+     * 任务id和线程池映射
+     */
+    private final ConcurrentMap<String, CompletableFuture<?>> taskFutures = new ConcurrentHashMap<>();
+
+    /**
+     * 任务id和okhttp连接映射
+     */
+    private final ConcurrentMap<String, AsyncTaskParamHolder> taskEventSource = new ConcurrentHashMap<>();
+
+    @Value("${task.async.pool-size:100}")
+    private int taskAsyncPoolSize;
+
+    @Value("${task.async.execute-lock-key}")
+    private String executeLock;
+
+    @Value("${task.async.clear-lock-key}")
+    private String clearLock;
+
+    @Autowired
+    private I18nUtil i18nUtil;
+
+    @Value("${env.type}")
+    private String envType;
+
+    /**
+     * 异步任务超期时间，建议调试记录超期时间保持一致
+     */
+    @Value("${task.async.expire-days:}")
+    private int taskAsyncExpireDays;
+
+    @Autowired
+    private RedisClient redisClient;
+
+    @Autowired
+    private AsyncTaskMapper asyncTaskMapper;
+
+    @Autowired
+    private WorkflowRuntimeService workflowRuntimeService;
+
+    @Autowired
+    private ConversationHistoryService conversationHistoryService;
+
+    @Autowired
+    private AgentServiceProxyService agentServiceProxyService;
+
+    @Value("${agent_runtime_endpoint:}")
+    private String runtimeEndpoint;
+
+    /**
+     * 线程池
+     */
+    private ExecutorService executor;
+
+    @PostConstruct
+    private void init() {
+        executor = Executors.newFixedThreadPool(taskAsyncPoolSize);
+    }
+
+    /**
+     * 定期拉起初始状态的任务
+     */
+    @Scheduled(cron = "${task.async.execute-cron-expression:}")
+    @Async
+    public void doAsyncTask() {
+        RedisLock lock = null;
+        boolean isLocked = false;
+        try {
+            lock = redisClient.getLock(executeLock);
+
+            // 获取redis分布式锁，如果锁不可用，则等待10秒，如果还是无法获取，则抛出异常
+            isLocked = lock.tryLock(Duration.ofSeconds(LOCK_TIME));
+            if (isLocked) {
+                findAndAsyncExecuteWorkflow();
+            } else {
+                log.warn("failed to get execute lock");
+            }
+        } catch (Exception e) {
+            log.error("async task execute failed!", e);
+        } finally {
+            if (lock != null && isLocked) {
+                try {
+                    lock.unlock();
+                } catch (Exception e) {
+                    log.warn("Failed to release lock", e);
+                }
+            }
+        }
+    }
+
+    /**
+     * 定期拉起清理超期的任务
+     */
+    @Scheduled(cron = "${task.async.clear-cron-expression:}")
+    @Async
+    public void clearExpiredMission() {
+        RedisLock lock = null;
+        boolean isLocked = false;
+        try {
+            lock = redisClient.getLock(clearLock);
+
+            // 获取redis分布式锁，如果锁不可用，则等待10秒，如果还是无法获取，则抛出异常
+            isLocked = lock.tryLock(Duration.ofSeconds(LOCK_TIME));
+            if (isLocked) {
+                long expireMillis = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(taskAsyncExpireDays);
+
+                // 获取超期任务
+                List<TaskEntity> expireTasks = asyncTaskMapper.getExpiredTaskEntity(new Date(expireMillis));
+                List<String> expireIds = expireTasks.stream().map(TaskEntity::getId).toList();
+
+                // 如当前任务仍在执行，需取消任务
+                expireIds.forEach(this::cancelTask);
+                asyncTaskMapper.deleteByIds(expireIds);
+            } else {
+                log.warn("failed to get clear lock");
+            }
+        } catch (Exception e) {
+            log.error("async task clear failed!", e);
+        } finally {
+            if (lock != null && isLocked) {
+                try {
+                    lock.unlock();
+                } catch (Exception e) {
+                    log.warn("Failed to release lock", e);
+                }
+            }
+        }
+    }
+
+    /**
+     * 找到并异步执行工作流
+     */
+    public void findAndAsyncExecuteWorkflow() {
+        // 获取当前空闲的线程池数
+        int idlePoolNum = taskAsyncPoolSize - taskFutures.size();
+
+        // 当前无空闲线程，拉起任务失败
+        if (idlePoolNum == 0) {
+            log.info("Current connection pool is full!");
+            return;
+        }
+        // 按当前空闲线程个数拉起服务
+        List<TaskEntity> taskEntities = asyncTaskMapper.getInitWorkflowTaskEntity(idlePoolNum);
+        if (CollectionUtils.isEmpty(taskEntities)) {
+            log.debug("Current async workflow task is empty!");
+            return;
+        }
+        taskEntities.forEach(taskEntity -> {
+            try {
+                submitAsyncTask(taskEntity.getId(), () -> executeWorkflow(taskEntity));
+            } catch (Exception e) {
+                log.error("Run workflow failed.", e);
+                throw new AgentStudioException(StudioError.WORKFLOW_ASYNC_EXECUTE_FAILED);
+            }
+            log.info("runWorkflowStream end.");
+        });
+    }
+
+    private ExecuteParams buildExecuteParams(TaskEntity entity) {
+        // 从redis读取用户header，并新增透传超时header
+        String headerStr = redisClient.get(String.format(REDIS_HEADER_KEY, entity.getId()));
+        HttpHeaders httpHeaders = new HttpHeaders();
+        Integer timeout = entity.getTimeout() != null ? entity.getTimeout() : DEFAULT_TIMEOUT_MILLISECONDS;
+        if (!StringUtils.isEmpty(headerStr)) {
+            Map<String, String> headers = JsonUtils.json2Obj(headerStr, new TypeReference<>() { });
+            if (headers != null) {
+                headers.put(KEEP_ALIVE, String.format(TIMEOUT_VALUE, timeout));
+                headers.forEach(httpHeaders::add);
+            }
+        } else {
+            httpHeaders.add(KEEP_ALIVE, String.format(TIMEOUT_VALUE, timeout));
+        }
+        // 异步任务以debug模式运行，确保runtime发送WORKFLOW_NODE_MESSAGE事件（包含节点执行详情）
+        httpHeaders.set("X-Invoke-Mode", "debug");
+        // 根据是否发布决定appVersion是发布态或编辑态时间
+        Long version = null;
+        String releaseVersion = null;
+        if (Boolean.TRUE.equals(entity.getIsPublished())) {
+            releaseVersion = entity.getAppVersion();
+        } else {
+            version = StringUtils.isEmpty(entity.getAppVersion()) ? null : Long.valueOf(entity.getAppVersion());
+        }
+        return ExecuteParams.builder()
+                .domainId(entity.getDomainId())
+                .projectId(entity.getProjectId())
+                .workspaceId(StringUtils.isNotEmpty(entity.getWorkspaceId()) ? entity.getWorkspaceId() : StringUtils.EMPTY)
+                .workflowId(entity.getAppId())
+                .debug(true)
+                .traceMode(Constant.Agent.DEBUG)
+                .trace(true)
+                .isTreasure(false)
+                .inputs(JsonUtils.json2Obj(entity.getInputs(), new TypeReference<>() { }))
+                .stream(false)
+                .isNodeExecute(false)
+                .startTime(System.currentTimeMillis())
+                .conversationId(entity.getConversationId())
+                .version(version)
+                .releasedVersion(releaseVersion)
+                .userId(entity.getUserId())
+                .inputsUserId(entity.getUserId())
+                .httpHeaders(httpHeaders)
+                .asyncTaskParamHolder(new AsyncTaskParamHolder(true, timeout))
+                .build();
+    }
+
+    private TaskStatus convertWorkflowRunStatus(Status status) {
+        // 九问事件转换成原始事件
+        switch (status.getDesc()) {
+            case "running" -> {
+                return TaskStatus.RUNNING;
+            }
+            case "succeeded" -> {
+                return TaskStatus.COMPLETED;
+            }
+            case "waiting" -> {
+                return TaskStatus.PENDING;
+            }
+            default -> {
+                return TaskStatus.FAILED;
+            }
+        }
+    }
+
+    private void executeWorkflow(TaskEntity taskEntity) {
+        // 工作流开始运行
+        ExecuteParams executeParams = buildExecuteParams(taskEntity);
+        try {
+            if ("simple".equals(envType)) {
+                String authToken = taskEntity.getUserId() + "|" + taskEntity.getProjectId();
+                RequestContextUtils.setRequestAuthTokenAndUserId(authToken, taskEntity.getProjectId(),
+                        taskEntity.getUserId());
+            } else {
+                String authToken = "";
+                RequestContextUtils.setRequestAuthTokenAndUserId(authToken, taskEntity.getProjectId(),
+                        taskEntity.getUserId());
+            }
+        } catch (Exception e) {
+            log.error("Call get-agency-token api exception.", e);
+            taskEntity.setStartTime(new Date(System.currentTimeMillis()));
+            taskEntity.setStatus(TaskStatus.FAILED.getValue());
+            taskEntity.setMessage(i18nUtil.getMessage(StudioError.ASYNC_TASK_ACCOUNT_FAILED));
+            asyncTaskMapper.updateByPrimaryKey(taskEntity);
+            return;
+        }
+
+        // 更新状态为执行中
+        Date startTime = new Date(System.currentTimeMillis());
+        taskEntity.setStartTime(startTime);
+        taskEntity.setUpdateTime(startTime);
+        taskEntity.setStatus(TaskStatus.RUNNING.getValue());
+        asyncTaskMapper.updateByPrimaryKey(taskEntity);
+
+        // 透传参数绑定连接池，便于取消任务时手动释放连接池
+        taskEventSource.put(taskEntity.getId(), executeParams.getAsyncTaskParamHolder());
+
+        WorkflowRunResult result = null;
+        AsyncWorkflowListener listener = null;
+        try {
+            // 通过流式通道调用runtime，AsyncWorkflowListener在manager侧保存调试记录并捕获消息内容
+            listener = createAsyncListener(executeParams);
+            result = callWorkflowViaStream(executeParams, listener);
+
+            // 轮询等待工作流执行完成
+            waitForWorkflowCompletion(result, executeParams);
+
+            // 从流式结果构建WorkflowRunRsp
+            WorkflowRunRsp workflowRunRsp = buildWorkflowRunRspFromResult(result, executeParams);
+
+            // 工作流运行结束或失败更新状态
+            Date finishTime = new Date(System.currentTimeMillis());
+            taskEntity.setUpdateTime(finishTime);
+            taskEntity.setFinishTime(finishTime);
+            if (workflowRunRsp.getStatus() != null) {
+                TaskStatus taskStatus = convertWorkflowRunStatus(workflowRunRsp.getStatus());
+                taskEntity.setStatus(taskStatus.getValue());
+
+                if (TaskStatus.FAILED.equals(taskStatus)) {
+                    taskEntity.setMessage(workflowRunRsp.getErrorMessage());
+                } else {
+                    taskEntity.setOutputs(JsonUtils.toJson(workflowRunRsp));
+                    taskEntity.setMessage(StringUtils.EMPTY);
+                }
+            } else {
+                // 说明latch已超时，工作流未返回，直接返回超时信息
+                taskEntity.setStatus(TaskStatus.FAILED.getValue());
+                taskEntity.setMessage(i18nUtil.getMessage(StudioError.ASYNC_TASK_EXECUTE_TIMEOUT));
+            }
+        } catch (AgentStudioException e) {
+            log.error("Execute workflow failed", e);
+            taskEntity.setStatus(TaskStatus.FAILED.getValue());
+            taskEntity.setMessage(StrUtils.truncateText(i18nUtil.getMessage(StudioError.ASYNC_TASK_EXECUTE_FAILED,
+                    i18nUtil.getMessage(e.getErrorCode(), e.getArgs())), MAX_ERROR_MESSAGE_SIZE));
+        } catch (Exception e) {
+            log.error("Execute workflow failed", e);
+            taskEntity.setStatus(TaskStatus.FAILED.getValue());
+            taskEntity.setMessage(
+                    StrUtils.truncateText(i18nUtil.getMessage(StudioError.ASYNC_TASK_EXECUTE_FAILED, e.getMessage()),
+                            MAX_ERROR_MESSAGE_SIZE));
+        }
+        // 如不是用户取消导致的失败，刷新状态
+        if (taskFutures.get(taskEntity.getId()) != null) {
+            asyncTaskMapper.updateByPrimaryKey(taskEntity);
+        }
+        // 任务执行结果记录到会话历史
+        saveConversationHistory(taskEntity, result, listener);
+    }
+
+    /**
+     * 将工作流执行结果写入会话历史。
+     * 成功时：优先从nodeRunInfoList中提取END节点输出，fallback到AsyncWorkflowListener捕获的message事件内容。
+     * 失败时：将错误信息作为assistant消息。
+     */
+    private void saveConversationHistory(TaskEntity taskEntity, WorkflowRunResult result,
+        AsyncWorkflowListener listener) {
+        ConversationParams conversationParams = new ConversationParams()
+                .setExecuteType(Constant.AppType.WORKFLOW)
+                .setId(taskEntity.getAppId())
+                .setConversationId(taskEntity.getConversationId());
+
+        Message message = new Message();
+        message.setRole(MessageRole.ASSISTANT.name().toLowerCase(Locale.ROOT));
+        message.setCreateTime(taskEntity.getUpdateTime() != null ? taskEntity.getUpdateTime().getTime()
+                : System.currentTimeMillis());
+
+        if (TaskStatus.COMPLETED.getValue().equals(taskEntity.getStatus()) && result != null) {
+            // 成功：优先从nodeRunInfoList提取，fallback到listener捕获的message事件内容
+            String content = extractWorkflowOutput(result, listener);
+            if (StringUtils.isNotEmpty(content)) {
+                message.setContent(content);
+                conversationHistoryService.updateConversation(conversationParams, List.of(message), true);
+            }
+        } else if (TaskStatus.FAILED.getValue().equals(taskEntity.getStatus())) {
+            // 失败：记录错误信息
+            if (StringUtils.isNotEmpty(taskEntity.getMessage())) {
+                message.setContent(taskEntity.getMessage());
+                conversationHistoryService.updateConversation(conversationParams, List.of(message), false);
+            }
+        }
+    }
+
+    /**
+     * 提取工作流最终输出内容。
+     * 优先从nodeRunInfoList中查找END节点的responseContent输出，
+     * 若nodeRunInfoList为空（manager侧WorkflowListener不保证填充node info），
+     * 则fallback到AsyncWorkflowListener从message事件中捕获的文本。
+     */
+    @SuppressWarnings("unchecked")
+    private String extractWorkflowOutput(WorkflowRunResult result, AsyncWorkflowListener listener) {
+        // 优先：从nodeRunInfoList中提取END节点输出
+        if (result.getNodeRunInfoList() != null && !result.getNodeRunInfoList().isEmpty()) {
+            for (int i = result.getNodeRunInfoList().size() - 1; i >= 0; i--) {
+                com.openjiuwen.studio.agent.common.dto.agent.NodeRunInfo node = result.getNodeRunInfoList().get(i);
+                if (node.getOutputs() != null && node.getOutputs() instanceof Map) {
+                    Map<String, Object> outputs = (Map<String, Object>) node.getOutputs();
+                    Object responseContent = outputs.get("responseContent");
+                    if (responseContent != null) {
+                        return responseContent.toString();
+                    }
+                }
+            }
+        }
+        // fallback：从AsyncWorkflowListener捕获的message事件内容中获取
+        if (listener != null && listener.getMessageContent().length() > 0) {
+            return listener.getMessageContent().toString();
+        }
+        return null;
+    }
+
+    /**
+     * 创建异步任务专用的WorkflowListener。
+     * 在callWorkflowViaStream之前创建，以便后续saveConversationHistory时引用其捕获的消息内容。
+     */
+    private AsyncWorkflowListener createAsyncListener(ExecuteParams executeParams) {
+        WorkflowRunResult result = initWorkflowRunResult(executeParams);
+        // requestId在异步线程中可能为null，WorkflowListener.processStart()会fallback到executionId
+        String requestId = org.slf4j.MDC.get("request-id");
+        return new AsyncWorkflowListener(requestId, executeParams, result, executeParams.getHttpHeaders());
+    }
+
+    /**
+     * 通过流式通道调用runtime工作流。
+     * 复用AgentServiceProxyService的stream()方法 + AsyncWorkflowListener，
+     * AsyncWorkflowListener负责解析SSE事件并保存调试记录（insight）到Redis。
+     *
+     * @param executeParams 执行参数
+     * @param listener      异步任务监听器（已持有WorkflowRunResult）
+     * @return WorkflowRunResult 流式执行结果
+     */
+    private WorkflowRunResult callWorkflowViaStream(ExecuteParams executeParams, AsyncWorkflowListener listener) {
+        // 1. 构建runtime工作流URL
+        String url = buildRuntimeWorkflowUrl(executeParams);
+
+        // 2. 构建WorkflowRunReq请求体
+        WorkflowRunReq reqBody = buildWorkflowRunReq(executeParams);
+
+        // 3. 设置executionId
+        String taskId = executeParams.getAsyncTaskParamHolder() != null
+                ? java.util.UUID.randomUUID().toString() : null;
+        if (taskId != null) {
+            executeParams.setExecutionId(taskId);
+        }
+        org.slf4j.MDC.put(Constant.TASK_ID, executeParams.getExecutionId());
+        executeParams.getHttpHeaders().set("X-Execution-Id", executeParams.getExecutionId());
+
+        // 4. 调用stream()发起SSE请求，AsyncWorkflowListener自动处理事件并保存调试记录
+        agentServiceProxyService.stream(url, executeParams.getHttpHeaders(),
+                JsonUtils.toJson(reqBody), 900000L, listener);
+
+        return listener.getResult();
+    }
+
+    /**
+     * 构建runtime工作流URL
+     */
+    private String buildRuntimeWorkflowUrl(ExecuteParams executeParams) {
+        String url = "%s/v1/%s/workflows/%s/conversations/%s?workspace_id=%s";
+        url = String.format(Locale.ROOT, url, runtimeEndpoint,
+                executeParams.getProjectId(), executeParams.getWorkflowId(),
+                executeParams.getConversationId(), executeParams.getWorkspaceId());
+        if (StringUtils.isNotEmpty(executeParams.getEnvironmentId())) {
+            url += "&environment_id=" + executeParams.getEnvironmentId();
+        }
+        // 发布态传releaseVersion，编辑态不传version
+        if (StringUtils.isNotEmpty(executeParams.getReleasedVersion())) {
+            url += "&version=" + executeParams.getReleasedVersion();
+        }
+        return url;
+    }
+
+    /**
+     * 构建WorkflowRunReq请求体
+     */
+    private WorkflowRunReq buildWorkflowRunReq(ExecuteParams executeParams) {
+        WorkflowRunReq reqBody = new WorkflowRunReq();
+        reqBody.setInputs(executeParams.getInputs());
+        return reqBody;
+    }
+
+    /**
+     * 初始化WorkflowRunResult和WorkflowInstanceEntity
+     * 复用AgentServiceProxyController中的初始化模式
+     */
+    private WorkflowRunResult initWorkflowRunResult(ExecuteParams executeParams) {
+        WorkflowRunResult result = new WorkflowRunResult();
+        WorkflowInstanceEntity instance = new WorkflowInstanceEntity();
+        instance.setConversationId(executeParams.getConversationId());
+        instance.setWorkflowId(executeParams.getWorkflowId());
+        instance.setInputs(executeParams.getInputs());
+        instance.setStatus(WorkflowRunStatus.RUNNING.getStatus().getDesc());
+        instance.setStartTime(executeParams.getStartTime());
+        instance.setEventList(new ArrayList<>());
+        instance.setUserId(executeParams.getUserId());
+        instance.setProjectId(executeParams.getProjectId());
+        result.setInstance(instance);
+        return result;
+    }
+
+    /**
+     * 轮询等待工作流执行完成。
+     * WorkflowListener在处理WORKFLOW_FINISHED或ERROR事件时设置taskEnd=true。
+     */
+    private void waitForWorkflowCompletion(WorkflowRunResult result, ExecuteParams executeParams) {
+        int timeout = (executeParams.getAsyncTaskParamHolder() != null)
+                ? executeParams.getAsyncTaskParamHolder().getTimeout()
+                : DEFAULT_TIMEOUT_MILLISECONDS;
+        long deadline = System.currentTimeMillis() + timeout;
+
+        while (!result.isTaskEnd()) {
+            if (System.currentTimeMillis() > deadline) {
+                log.warn("Async workflow polling timeout reached for conversationId: {}",
+                        executeParams.getConversationId());
+                return;
+            }
+            try {
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new AgentStudioException(StudioError.WORKFLOW_ASYNC_EXECUTE_FAILED);
+            }
+        }
+    }
+
+    /**
+     * 从WorkflowRunResult构建WorkflowRunRsp。
+     * 将流式执行结果转换为与原runWorkflow返回值一致的结构。
+     */
+    private WorkflowRunRsp buildWorkflowRunRspFromResult(WorkflowRunResult result, ExecuteParams executeParams) {
+        WorkflowInstanceEntity instance = result.getInstance();
+
+        // 从instance状态构建Status
+        Status status = null;
+        if (instance != null && StringUtils.isNotEmpty(instance.getStatus())) {
+            status = WorkflowRunStatus.SUCCEEDED.getStatus().getDesc().equals(instance.getStatus())
+                    ? WorkflowRunStatus.SUCCEEDED.getStatus()
+                    : WorkflowRunStatus.FAILED.getStatus().getDesc().equals(instance.getStatus())
+                    ? WorkflowRunStatus.FAILED.getStatus()
+                    : WorkflowRunStatus.RUNNING.getStatus().getDesc().equals(instance.getStatus())
+                    ? WorkflowRunStatus.RUNNING.getStatus()
+                    : WorkflowRunStatus.FAILED.getStatus();
+        }
+
+        // 从WorkflowListener收集的结果构建WorkflowRunRsp
+        WorkflowRunRsp rsp = new WorkflowRunRsp();
+        rsp.setNodeInfo(result.getNodeRunInfoList() != null ? result.getNodeRunInfoList() : new ArrayList<>());
+        rsp.setStartTime(executeParams.getStartTime());
+        rsp.setEndTime(instance != null ? instance.getEndTime() : System.currentTimeMillis());
+        rsp.setStatus(status);
+        rsp.setErrorMessage(instance != null ? instance.getErrorInfo() : null);
+
+        return rsp;
+    }
+
+    /**
+     * 提交异步任务
+     *
+     * @param taskId 任务id
+     * @param task 任务
+     */
+    public void submitAsyncTask(String taskId, Runnable task) {
+        CompletableFuture<Void> future = CompletableFuture.runAsync(task, executor);
+        taskFutures.put(taskId, future);
+
+        // 任务结束释放
+        future.whenComplete((result, exception) -> {
+            if (taskFutures.get(taskId) != null) {
+                taskFutures.remove(taskId);
+            }
+            if (taskEventSource.get(taskId) != null) {
+                taskEventSource.remove(taskId);
+            }
+        });
+    }
+
+    /**
+     * 取消任务
+     *
+     * @param taskId 任务id
+     */
+    public void cancelTask(String taskId) {
+        AsyncTaskParamHolder asyncTaskParamHolder = taskEventSource.get(taskId);
+
+        // 释放线程池
+        if (asyncTaskParamHolder != null) {
+            if (asyncTaskParamHolder.getEventSource() != null) {
+                asyncTaskParamHolder.getEventSource().cancel();
+            }
+            taskEventSource.remove(taskId);
+        }
+        // 释放异步连接池
+        CompletableFuture<?> future = taskFutures.get(taskId);
+        if (future != null) {
+            future.cancel(true);
+            taskFutures.remove(taskId);
+        }
+    }
+
+    /**
+     * 释放资源
+     */
+    public void shutdown() {
+        executor.shutdown();
+    }
+}

--- a/backend/studio-manager-service/src/main/java/com/openjiuwen/studio/agent/manager/service/proxy/AgentServiceProxyService.java
+++ b/backend/studio-manager-service/src/main/java/com/openjiuwen/studio/agent/manager/service/proxy/AgentServiceProxyService.java
@@ -291,76 +291,12 @@ public class AgentServiceProxyService {
         return runtimeClient.resetUserVariableMemory(getToken(), projectId, agentId, workspaceId);
     }
 
-    public ResponseEntity<List<Message>> retrieveConversation(String projectId, String agentId, String conversationId,
-        RetrieveConversationQo retrieveConversationQo, String workspaceId) {
 
-        // agentId可能是workflowId
-        try {
-            checkWorkflowPermission(projectId, workspaceId, agentId);
-        } catch (AgentStudioException e) {
-            if (StudioError.WORKFLOW_NOT_EXIST == e.getErrorCode()) {
-                checkAgentPermission(projectId, workspaceId, agentId);
-            } else {
-                throw e;
-            }
-        }
-        return runtimeClient.retrieveConversation(getToken(), projectId, agentId, conversationId,
-            retrieveConversationQo, workspaceId);
-    }
 
-    public ResponseEntity<ConversationDeleteResp> deleteConversation(String projectId, String agentId,
-        String conversationId, String versionId, String workspaceId) {
-        checkAgentPermission(projectId, workspaceId, agentId);
-        return runtimeClient.deleteConversation(getToken(), projectId, agentId, conversationId, versionId, workspaceId);
-    }
 
-    public ResponseEntity<TaskRsp> createTask(String projectId, String workflowId, String version, String workspaceId,
-        CreateTaskReq body) {
 
-        checkWorkflowPermission(projectId, workspaceId, workflowId);
-        return runtimeClient.createTask(getToken(), projectId, workflowId, version, workspaceId, body);
-    }
 
-    public ResponseEntity<TaskListRsp> listTask(String projectId, String workflowId, ListTaskQo listTaskQo,
-        String workspaceId) {
 
-        checkWorkflowPermission(projectId, workspaceId, workflowId);
-        return runtimeClient.listTask(getToken(), projectId, workflowId, listTaskQo.getStatus(), listTaskQo.getType(), listTaskQo.getSort(), listTaskQo.getOrder(), workspaceId);
-    }
-
-    public ResponseEntity<TaskRsp> retrieveTask(String projectId, String workflowId, String taskId, String workspaceId) {
-
-        checkWorkflowPermission(projectId, workspaceId, workflowId);
-        return runtimeClient.retrieveTask(getToken(), projectId, workflowId, taskId, workspaceId);
-    }
-
-    public ResponseEntity<TaskRsp> resumeTask(String projectId, String workflowId, String taskId, String workspaceId,
-        ResumeTaskReq body) {
-
-        checkWorkflowPermission(projectId, workspaceId, workflowId);
-        return runtimeClient.resumeTask(getToken(), projectId, workflowId, taskId, workspaceId, body);
-    }
-
-    public ResponseEntity<TaskRsp> modifyTask(String projectId, String workflowId, String taskId, String workspaceId,
-        ModifyTaskReq body) {
-
-        checkWorkflowPermission(projectId, workspaceId, workflowId);
-        return runtimeClient.modifyTask(getToken(), projectId, workflowId, taskId, workspaceId, body);
-    }
-
-    public ResponseEntity<CommonDeleteRsp> deleteTask(String projectId, String workflowId, String taskId,
-        String workspaceId) {
-
-        checkWorkflowPermission(projectId, workspaceId, workflowId);
-        return runtimeClient.deleteTask(getToken(), projectId, workflowId, taskId, workspaceId);
-    }
-
-    public ResponseEntity<CancelTaskRsp> cancelTask(String projectId, String workflowId, String taskId,
-        String workspaceId) {
-
-        checkWorkflowPermission(projectId, workspaceId, workflowId);
-        return runtimeClient.cancelTask(getToken(), projectId, workflowId, taskId, workspaceId);
-    }
 
     public ResponseEntity<McpValidationResp> testServer(String projectId, McpValidationReq body, String workspaceId) {
 

--- a/backend/studio-manager-service/src/main/java/com/openjiuwen/studio/agent/manager/service/proxy/AsyncWorkflowListener.java
+++ b/backend/studio-manager-service/src/main/java/com/openjiuwen/studio/agent/manager/service/proxy/AsyncWorkflowListener.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) Huawei Technologies Co., Ltd. 2026-2026. All rights reserved.
+ */
+
+package com.openjiuwen.studio.agent.manager.service.proxy;
+
+import com.alibaba.fastjson2.JSONObject;
+import com.openjiuwen.studio.agent.manager.entity.insight.WorkflowInstanceEntity;
+import com.openjiuwen.studio.agent.manager.entity.insight.WorkflowRunResult;
+import com.openjiuwen.studio.agent.manager.enums.WorkflowRunStatus;
+import com.openjiuwen.studio.agent.manager.model.ExecuteParams;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.Response;
+import okhttp3.sse.EventSource;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.MDC;
+import org.springframework.http.HttpHeaders;
+
+/**
+ * 异步任务专用的工作流监听器。
+ * 继承WorkflowListener，复用事件解析和调试记录保存逻辑，
+ * 额外处理异步任务场景下的四个特殊需求：
+ *
+ * 1. passThrough()为空操作：异步任务无前端消费SseEmitter，跳过SSE转发。
+ *
+ * 2. 捕获message事件内容：WorkflowListener对message事件仅passThrough，
+ *    但异步任务需要保存assistant回复到会话历史，因此在此提取message事件中的文本。
+ *
+ * 3. onFailure时标记taskEnd=true：解除TaskRuntimeService的轮询阻塞。
+ *    原WorkflowListener的onFailure不设置taskEnd，因为流式场景由前端SSE连接关闭驱动。
+ *
+ * 4. onFailure时设置instance状态为FAILED并保存调试记录。
+ *    OkHttp SSE的onFailure和onClosed互斥（只触发其一），
+ *    原WorkflowListener仅在onClosed->saveInstance()中保存，
+ *    导致onFailure路径下调试记录丢失。
+ */
+@Slf4j
+public class AsyncWorkflowListener extends WorkflowListener {
+
+    /**
+     * 从message事件中提取的工作流输出内容，用于保存assistant回复到会话历史。
+     * 使用StringBuilder累积多次message事件的文本。
+     */
+    @Getter
+    private final StringBuilder messageContent = new StringBuilder();
+
+    public AsyncWorkflowListener(String requestId, ExecuteParams executeParams, WorkflowRunResult result,
+        HttpHeaders headers) {
+        super(requestId, executeParams, result, headers);
+    }
+
+    /**
+     * 获取WorkflowRunResult（包含instance和nodeRunInfoList）。
+     * result字段继承自WorkflowListener（protected），此getter供TaskRuntimeService访问。
+     */
+    public WorkflowRunResult getResult() {
+        return result;
+    }
+
+    /**
+     * 异步任务无前端消费SseEmitter，跳过SSE转发避免无意义的send error日志。
+     */
+    @Override
+    protected void passThrough(String data) {
+        // no-op: 异步任务不转发SSE事件
+    }
+
+    /**
+     * 在每个事件被process()处理后，额外捕获message事件中的文本内容。
+     * 工作流的assistant回复通过message事件推送，WorkflowListener本身不存储这些内容，
+     * 异步任务需要在此提取以便后续保存到会话历史。
+     */
+    @Override
+    public void onEvent(@NotNull EventSource eventSource, @Nullable String id, @Nullable String type,
+        @NotNull String data) {
+        super.onEvent(eventSource, id, type, data);
+        captureMessageContent(data);
+    }
+
+    /**
+     * 从message类型的SSE事件中提取文本内容。
+     * 九问引擎的message事件结构：{"event":"message","data":{"text":"...","answer":"...",...},...}
+     *
+     * 字段语义：
+     * - text: 增量文本片段（流式LLM节点每帧推送一小段）
+     * - answer: 完整累积文本（流式LLM节点包含截至当前帧的全部文本）
+     *
+     * 策略：
+     * - 优先使用answer字段（完整文本，直接替换）
+     * - 无answer时累积text字段（增量chunk，逐帧追加）
+     */
+    private void captureMessageContent(String eventStr) {
+        try {
+            JSONObject eventObj = JSONObject.parseObject(eventStr);
+            if (!"message".equals(eventObj.getString("event"))) {
+                return;
+            }
+            JSONObject dataObj = eventObj.getJSONObject("data");
+            if (dataObj == null) {
+                return;
+            }
+            // answer字段存在时，包含完整累积文本，直接替换
+            Object answer = dataObj.get("answer");
+            if (answer != null) {
+                String answerStr = answer.toString();
+                if (!answerStr.isEmpty()) {
+                    messageContent.setLength(0);
+                    messageContent.append(answerStr);
+                }
+                return;
+            }
+            // 无answer字段时，text为增量内容，累积追加
+            String text = dataObj.getString("text");
+            if (text != null && !text.isEmpty()) {
+                messageContent.append(text);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to capture message content from event", e);
+        }
+    }
+
+    @Override
+    public void onFailure(@NotNull EventSource eventSource, @Nullable Throwable t, @Nullable Response response) {
+        MDC.put(REQUEST_ID, requestId);
+        try {
+            executeParams.setSuccess(-1);
+            log.error("Async workflow process failed. Throwable: {}, Response: {}", t, response);
+
+            // 标记任务结束，解除TaskRuntimeService.waitForWorkflowCompletion()的轮询阻塞
+            result.setTaskEnd(true);
+
+            // 设置instance为FAILED状态（saveInstance内部会判断：
+            // 如果status是RUNNING且workflowEnd=false，会错误地覆盖为SUCCEEDED，
+            // 所以必须在saveInstance之前显式设为FAILED）
+            WorkflowInstanceEntity instance = result.getInstance();
+            if (instance != null) {
+                instance.setStatus(WorkflowRunStatus.FAILED.getStatus().getDesc());
+                instance.setEndTime(System.currentTimeMillis());
+                if (t != null) {
+                    instance.setErrorInfo(t.getMessage());
+                } else if (response != null) {
+                    instance.setErrorInfo("Runtime request failed, HTTP " + response.code());
+                }
+            }
+
+            // onFailure与onClosed互斥，必须在此保存调试记录，否则丢失
+            saveInstance();
+
+            this.errorRsp = createErrorRsp(t, response);
+            this.openConnect = true;
+        } catch (Exception e) {
+            log.error("Fail handler response. {}", e.getMessage());
+            this.openConnect = true;
+        } finally {
+            try {
+                sseEmitter.complete();
+            } catch (Throwable e) {
+                log.warn("Fail close sse. {}", e.getMessage());
+            }
+        }
+    }
+}

--- a/backend/studio-manager-service/src/main/java/com/openjiuwen/studio/agent/manager/service/proxy/WorkflowListener.java
+++ b/backend/studio-manager-service/src/main/java/com/openjiuwen/studio/agent/manager/service/proxy/WorkflowListener.java
@@ -42,9 +42,9 @@ public class WorkflowListener extends BaseEventListener {
 
     private final JiuwenEventProcessor eventProcessor;
 
-    private final ExecuteParams executeParams;
+    protected final ExecuteParams executeParams;
 
-    private final WorkflowRunResult result;
+    protected final WorkflowRunResult result;
 
     private static final String JIUWEN_EXCEPTION_NODE_ID = "jiuwen_exception_node_id";
 
@@ -257,7 +257,7 @@ public class WorkflowListener extends BaseEventListener {
         }
     }
 
-    private void saveInstance() {
+    protected void saveInstance() {
         WorkflowInstanceEntity instance = result.getInstance();
         if (instance == null) {
             return;

--- a/backend/studio-manager-service/src/main/resources/application-manager.yml
+++ b/backend/studio-manager-service/src/main/resources/application-manager.yml
@@ -856,3 +856,13 @@ auth:
     defaults:
       domain-id: ${user_info_defaults_domain_id:0}
       project-id: ${user_info_defaults_project_id:0}
+
+task:
+  async:
+    pool-size: ${task_async_pool_size:100}
+    execute-cron-expression: ${task_async_execute_cron_expression:0/30 * * * * ?}
+    expire-days: ${task_async_expire_days:7}
+    clear-cron-expression: ${task_async_clear_cron_expression:0 0 2 */7 * ?}
+    max-execute-milliseconds: ${task_async_max_execute_milliseconds:172800000}
+    execute-lock-key: ${task_async_execute_lock_key:async_execute_lock}
+    clear-lock-key: ${task_async_clear_lock_key:async_clear_lock}

--- a/backend/studio-manager-service/src/main/resources/mapper/AsyncTaskMapper.xml
+++ b/backend/studio-manager-service/src/main/resources/mapper/AsyncTaskMapper.xml
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8"?><!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.openjiuwen.studio.agent.manager.mapper.AsyncTaskMapper">
+    <resultMap id="BaseResultMap" type="com.openjiuwen.studio.agent.manager.entity.TaskEntity">
+        <id column="id" jdbcType="VARCHAR" property="id"/>
+        <result column="name" jdbcType="VARCHAR" property="name"/>
+        <result column="conversation_id" jdbcType="VARCHAR" property="conversationId"/>
+        <result column="user_id" jdbcType="VARCHAR" property="userId"/>
+        <result column="project_id" jdbcType="VARCHAR" property="projectId"/>
+        <result column="domain_id" jdbcType="VARCHAR" property="domainId"/>
+        <result column="workspace_id" jdbcType="VARCHAR" property="workspaceId"/>
+        <result column="type" jdbcType="VARCHAR" property="type"/>
+        <result column="mode" jdbcType="VARCHAR" property="mode"/>
+        <result column="app_id" jdbcType="VARCHAR" property="appId"/>
+        <result column="app_version" jdbcType="VARCHAR" property="appVersion"/>
+        <result column="is_published" jdbcType="TINYINT" property="isPublished"/>
+        <result column="status" jdbcType="VARCHAR" property="status"/>
+        <result column="inputs" jdbcType="VARCHAR" property="inputs"/>
+        <result column="outputs" jdbcType="VARCHAR" property="outputs"/>
+        <result column="timeout" jdbcType="INTEGER" property="timeout"/>
+        <result column="message" jdbcType="VARCHAR" property="message"/>
+        <result column="create_time" jdbcType="TIMESTAMP" property="createTime"/>
+        <result column="start_time" jdbcType="TIMESTAMP" property="startTime"/>
+        <result column="update_time" jdbcType="TIMESTAMP" property="updateTime"/>
+        <result column="finish_time" jdbcType="TIMESTAMP" property="finishTime"/>
+    </resultMap>
+
+    <sql id="Base_Column_List">
+        id,
+        `name`,
+        conversation_id,
+        user_id,
+        project_id,
+        domain_id,
+        workspace_id,
+        `type`,
+        mode,
+        app_id,
+        app_version,
+        is_published,
+        status,
+        inputs,
+        outputs,
+        timeout,
+        message,
+        create_time,
+        start_time,
+        update_time,
+        finish_time
+    </sql>
+    <insert id="createEntity"
+            parameterType="com.openjiuwen.studio.agent.manager.entity.TaskEntity">
+        insert into t_task (id, name, conversation_id, user_id, project_id, domain_id, workspace_id, type, mode,
+                            app_id, app_version, is_published, status, inputs, outputs, timeout, create_time,
+                            start_time, update_time, finish_time)
+        values (#{entity.id,jdbcType=VARCHAR}, #{entity.name,jdbcType=VARCHAR},
+                #{entity.conversationId,jdbcType=VARCHAR}, #{entity.userId,jdbcType=VARCHAR},
+                #{entity.projectId,jdbcType=VARCHAR}, #{entity.domainId,jdbcType=VARCHAR},
+                #{entity.workspaceId,jdbcType=VARCHAR}, #{entity.type,jdbcType=VARCHAR},
+                #{entity.mode,jdbcType=VARCHAR}, #{entity.appId,jdbcType=VARCHAR},
+                #{entity.appVersion,jdbcType=VARCHAR}, #{entity.isPublished,jdbcType=TINYINT},
+                #{entity.status,jdbcType=VARCHAR}, #{entity.inputs,jdbcType=VARCHAR},
+                #{entity.outputs,jdbcType=VARCHAR}, #{entity.timeout,jdbcType=INTEGER},
+                #{entity.createTime,jdbcType=TIMESTAMP}, #{entity.startTime,jdbcType=TIMESTAMP},
+                #{entity.updateTime,jdbcType=TIMESTAMP}, #{entity.finishTime,jdbcType=TIMESTAMP})
+    </insert>
+    <select id="getTaskEntity" parameterType="com.openjiuwen.studio.agent.manager.entity.TaskEntity"
+            resultMap="BaseResultMap">
+        select
+        <include refid="Base_Column_List"/>
+        from t_task
+        where 1 = 1
+        <if test="entity.id != null and entity.id != ''">
+            and id=#{entity.id}
+        </if>
+        <if test="entity.projectId != null and entity.projectId != ''">
+            and project_id=#{entity.projectId}
+        </if>
+        <if test="entity.workspaceId != null and entity.workspaceId != ''">
+            and workspace_id=#{entity.workspaceId}
+        </if>
+        <if test="entity.name != null and entity.name != ''">
+            and `name` like concat('%', #{entity.name,jdbcType=VARCHAR}, '%')
+        </if>
+        <if test="entity.type != null and entity.type != ''">
+            and `type`=#{entity.type}
+        </if>
+        <if test="entity.mode != null and entity.mode != ''">
+            and mode=#{entity.mode}
+        </if>
+        <if test="entity.appId != null and entity.appId != ''">
+            and app_id=#{entity.appId}
+        </if>
+        <if test="entity.appVersion != null and entity.appVersion != ''">
+            and app_version=#{entity.appVersion}
+        </if>
+        <if test="entity.status != null and entity.status != ''">
+            and status=#{entity.status}
+        </if>
+        order by
+        <choose>
+            <when test="sort != null and sort == 'create_time'">
+                create_time
+            </when>
+            <otherwise>
+                #{sort}
+            </otherwise>
+        </choose>
+        <choose>
+            <when test="order != null and order == 'asc'">
+                asc
+            </when>
+            <otherwise>
+                desc
+            </otherwise>
+        </choose>
+    </select>
+    <update id="updateByPrimaryKey"
+            parameterType="com.openjiuwen.studio.agent.manager.entity.TaskEntity">
+        update t_task
+        <set>
+            <if test="entity.name != null">
+                `name` = #{entity.name, jdbcType=VARCHAR},
+            </if>
+            <if test="entity.status != null">
+                status = #{entity.status, jdbcType=VARCHAR},
+            </if>
+            <if test="entity.message != null">
+                message = #{entity.message, jdbcType=VARCHAR},
+            </if>
+            <if test="entity.inputs != null">
+                inputs = #{entity.inputs, jdbcType=VARCHAR},
+            </if>
+            <if test="entity.outputs != null">
+                outputs = #{entity.outputs, jdbcType=VARCHAR},
+            </if>
+            <if test="entity.timeout != null">
+                timeout = #{entity.timeout, jdbcType=INTEGER},
+            </if>
+            <if test="entity.startTime != null">
+                start_time = #{entity.startTime, jdbcType=TIMESTAMP},
+            </if>
+            <if test="entity.updateTime != null">
+                update_time = #{entity.updateTime, jdbcType=TIMESTAMP},
+            </if>
+            <if test="entity.finishTime != null">
+                finish_time = #{entity.finishTime, jdbcType=TIMESTAMP},
+            </if>
+        </set>
+        where id = #{entity.id, jdbcType=VARCHAR}
+        and project_id = #{entity.projectId, jdbcType=VARCHAR}
+        and user_id = #{entity.userId, jdbcType=VARCHAR}
+    </update>
+    <select id="getInitWorkflowTaskEntity" parameterType="com.openjiuwen.studio.agent.manager.entity.TaskEntity"
+            resultMap="BaseResultMap">
+        select
+        <include refid="Base_Column_List"/>
+        from t_task
+        where status='INIT' and (`type`='chat' or `type`='task')
+        order by create_time asc limit #{limit, jdbcType=INTEGER}
+    </select>
+    <select id="getExpiredTaskEntity" parameterType="com.openjiuwen.studio.agent.manager.entity.TaskEntity"
+            resultMap="BaseResultMap">
+        select
+        <include refid="Base_Column_List"/>
+        from t_task
+        where finish_time is not null and finish_time &lt;= #{expireTime, jdbcType=TIMESTAMP}
+    </select>
+    <delete id="deleteByIds" parameterType="map">
+        delete
+        from t_task
+        where id in
+        <foreach collection="ids" item="taskId" open="(" separator="," close=")">
+            #{taskId, jdbcType=VARCHAR}
+        </foreach>
+    </delete>
+</mapper>

--- a/backend/studio-manager-service/src/main/resources/sql/ddl.sql
+++ b/backend/studio-manager-service/src/main/resources/sql/ddl.sql
@@ -2153,3 +2153,32 @@ CREATE TABLE IF NOT EXISTS `t_mapping_tool_function`
     PRIMARY KEY (`id`),
     KEY  `idx_t_mapping_tool_function_updated_on` (`updated_on`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci ROW_FORMAT=DYNAMIC COMMENT='tool和function多对多关系映射表';
+
+CREATE TABLE IF NOT EXISTS `t_task` (
+                                        `id`                VARCHAR(64)     NOT NULL COMMENT '任务 id， 主键',
+    `name`              VARCHAR(64)     NOT NULL COMMENT '任务名称，可修改',
+    `conversation_id`   VARCHAR(64)     NULL COMMENT '会话ID',
+    `user_id`           VARCHAR(64)     NULL COMMENT 'user id',
+    `project_id`        VARCHAR(64)     NULL COMMENT 'project id',
+    `domain_id`         VARCHAR(64)     NULL COMMENT 'domain id',
+    `workspace_id`      VARCHAR(64)     NULL COMMENT 'workspace id',
+    `type`              VARCHAR(32)     NULL COMMENT '任务类型',
+    `mode`              VARCHAR(32)     NULL COMMENT '任务模式，当前仅支持ASYNC',
+    `app_id`            VARCHAR(64)     NULL COMMENT '对应工作流或agent id',
+    `app_version`       VARCHAR(128)    NULL COMMENT '任务应用版本',
+    `is_published`      TINYINT(1)      NULL COMMENT '此工作流是否是发布后',
+    `status`            VARCHAR(32)     NULL COMMENT '任务状态',
+    `inputs`            MEDIUMTEXT      NULL COMMENT '任务输入',
+    `outputs`           MEDIUMTEXT      NULL COMMENT '任务输出',
+    `timeout`           INTEGER         NULL COMMENT '工作流超时时间',
+    `message`           VARCHAR(2048)   NULL COMMENT '提示消息',
+    `create_time`       TIMESTAMP       NOT NULL COMMENT '创建时间',
+    `start_time`        TIMESTAMP       NULL COMMENT '任务实际开始时间',
+    `update_time`       TIMESTAMP       NULL COMMENT '任务更新日期',
+    `finish_time`       TIMESTAMP       NULL COMMENT '任务结束日期',
+    PRIMARY KEY (`id`),
+    INDEX `idx_create_time`(`create_time` ASC) USING BTREE,
+    INDEX `idx_status_time`(`status` ASC, `create_time` ASC) USING BTREE,
+    INDEX `idx_finish_time`(`finish_time` ASC) USING BTREE
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci ROW_FORMAT=DYNAMIC COMMENT='任务记录表';
+


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

<!--  Thanks for sending a pull request!  Here are some tips for you:

1) If this is your first time, please read our contributor guidelines: https://gitcode.com/openJiuwen/community/blob/master/CONTRIBUTING.md

2) If you want to contribute your code but don't know who will review and merge, please add label `openjiuwen-assistant` to the pull request, we will find and do it as soon as possible.
-->

**What type of PR is this?**
<!-- 
选择下面一种标签替换下方 `/kind <label>`，可选标签类型有：
- /kind bug 
- /kind task
- /kind feature
- /kind refactor
- /kind clean_code
如PR描述不符合规范，修改PR描述后需要/check-pr重新检查PR规范。
-->
/kind <label>


**Self-checklist**:（**请自检，在[ ]内打上x，我们将检视你的完成情况，否则会导致pr无法合入**）

+ - [x] **设计**：PR对应的方案是否已经经过Maintainer评审，方案检视意见是否均已答复并完成方案修改
+ - [x] **测试**：PR中的代码是否已有UT/ST测试用例进行充分的覆盖，新增测试用例是否随本PR一并上库或已经上库
+ - [x] **验证**：PR描述信息中是否已包含对该PR对应的Feature、Refactor、Bugfix的预期目标达成情况的详细验证结果描述
+ - [ ] **接口**：是否涉及对外接口变更，相应变更已得到接口评审组织的通过，API对应的注释信息已经刷新正确
+ - [ ] **文档**：是否涉及官网文档修改，如果涉及请及时提交资料到Doc仓

<!-- **Special notes for your reviewers**: -->
<!-- + - [ ] 是否导致无法前向兼容 -->
<!-- + - [ ] 是否涉及依赖的三方库变更 -->

  - 新增 TaskManagementApi/ConversationHistoryApi 及对应 Controller
- 新增 TaskRuntimeService 实现任务提交、轮询、取消、过期清理等生命周期管理
- 新增 TaskManagementService 实现任务 CRUD 操作
- 新增 AsyncWorkflowListener 处理异步工作流 SSE 事件并持久化到数据库
- 新增 t_task 数据库表及 MyBatis Mapper (AsyncTaskMapper)
- 删除 studio-agent-service-proxy 中已迁移的 Controller 和 Service
- AgentRuntimeClient 简化：移除批量查询/流式接口，
- 支持通过配置文件控制任务并发数、过期天数、清理时间等参数