### PR TITLE
fix:智能体试运行出错时，SSE error 事件响应中缺少 workflow_id 字段

### DIFF
--- a/agent-runtime/agent_runtime/event_handler/base/field_processor.py
+++ b/agent-runtime/agent_runtime/event_handler/base/field_processor.py
@@ -119,6 +119,8 @@ class FieldDataProcessor:
             error_reason=error_reason,
             error_suggestion=error_suggestion,
             error_code=error_code,
+            workflow_id=trace.workflow_id,
+            workflow_name=trace.workflow_name,
         )
         create_time = trace.end_time
         if create_time is None:

--- a/agent-runtime/agent_runtime/event_handler/base/trace.py
+++ b/agent-runtime/agent_runtime/event_handler/base/trace.py
@@ -91,6 +91,8 @@ class Trace:
     block: bool = False
     execution_id: Optional[str] = None
     pre_event: Optional[str] = None
+    workflow_id: Optional[str] = None
+    workflow_name: Optional[str] = None
 
     def overall_time(self) -> float:
         if self.end_time is None:

--- a/agent-runtime/agent_runtime/event_handler/events/base_events.py
+++ b/agent-runtime/agent_runtime/event_handler/events/base_events.py
@@ -117,6 +117,8 @@ class BaseEventsProcessor(ABC):
         trace.end_time = full_data.get("createdTime")
         data = full_data.get("data", {})
         code = data.get("code", 999999)
+        trace.workflow_id = data.get("workflow_id")
+        trace.workflow_name = data.get("workflow_name")
         error_code, error_msg, error_reason, error_suggestion = (
             ErrorContextBuilder.get_language_context(trace.language, code))
         error_data_field = ErrorEventDataField(
@@ -126,6 +128,8 @@ class BaseEventsProcessor(ABC):
             error_reason=error_reason,
             error_suggestion=error_suggestion,
             error_code=error_code,
+            workflow_id=data.get("workflow_id"),
+            workflow_name=data.get("workflow_name"),
         )
         error_field = EventField(
             event=ConversationEvent.ERROR.value,


### PR DESCRIPTION
<!-- bot0-gitcode-native-export -->

## 问题

智能体试运行出错时，SSE error 事件响应中缺少 workflow_id 字段，导致前端无法追踪出错的工作流实例。

## 原因

ReAct/PlanExecute 和 Controller 模式下，AgentEventsProcessor 和 ControllerEventsProcessor 均未覆盖 error 事件处理器，fallback 到基类 BaseEventsProcessor.process_error_event。该方法构建 ErrorEventDataField 时未传入 workflow_id，而纯 Workflow 模式的 WorkflowEventsProcessor.process_error_message 原本已有该字段。

此外，异常兜底路径 FieldDataProcessor.generate_error_event_field 从 trace 对象构建 error 事件，Trace 类缺少 workflow_id 字段。

## 修改内容

- `base_events.py`：process_error_event 补充 workflow_id、workflow_name，并记录到 trace
- `trace.py`：Trace 类新增 workflow_id、workflow_name 字段
- `field_processor.py`：异常兜底路径 generate_error_event_field 从 trace 取 workflow_id

## 验证

两层 Controller 智能体下挂工作流场景测试通过，F12 Network SSE 响应中已包含 workflow_id。